### PR TITLE
Functional gn jn

### DIFF
--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -199,7 +199,9 @@ if ($opt_nameU) {
 
 # Display
 $ostreamReport->print($stringPrint);
-if ($opt_output) { print_time("$stringPrint");} # When ostreamReport is a file we have to also display on screen
+if ($opt_output) {
+  print_time("$stringPrint");
+} # When ostreamReport is a file we have to also display on screen
 
 
 
@@ -238,7 +240,9 @@ if (defined $opt_BlastFile) {
   $db = Bio::DB::Fasta->new($opt_dataBase);
   # save ID in lower case to avoid cast problems
   my @ids = $db->get_all_primary_ids;
-  foreach my $id (@ids) {$allIDs{lc($id)} = $id;}
+  foreach my $id (@ids) {
+    $allIDs{lc($id)} = $id;
+  }
   print_time("Parsing Finished\n\n");
   #print "id.".$id"\t";
 
@@ -300,13 +304,17 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
           if (exists ($nameBlast{$nameClean})) { # We check that is really a name where we added the suffix _1
             $nameToCompare = $nameClean;
           }
-          else {$nameToCompare = $geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
+          else {
+            $nameToCompare = $geneNameBlast{$id_level1};
+          } # it was already a gene_name like BLABLA_12
 
           if (exists ($geneNameGiven{$nameToCompare})) {
             $nbDuplicateNameGiven++; # track total
             $duplicateNameGiven{$nameToCompare}++; # track diversity
           }
-          else {$geneNameGiven{$nameToCompare}++;} # first time we have given this name
+          else {
+            $geneNameGiven{$nameToCompare}++;
+          } # first time we have given this name
         }
       }
 
@@ -418,7 +426,9 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
 
         my $letter_tag = get_letter_tag($primary_tag_level1);
 
-        if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag} = $nbIDstart;}
+        if (! exists_keys(\%numbering,($letter_tag))) {
+          $numbering{$letter_tag} = $nbIDstart;
+        }
         $newID_level1 = manageID($prefixName, $numbering{$letter_tag}, $letter_tag );
         $numbering{$letter_tag }++;
         create_or_replace_tag($feature_level1, 'ID', $newID_level1);
@@ -441,7 +451,9 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
               }
 
               my $letter_tag = get_letter_tag($primary_tag_level2);
-              if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag} = $nbIDstart;}
+              if (! exists_keys(\%numbering,($letter_tag))) {
+                $numbering{$letter_tag} = $nbIDstart;
+              }
               $newID_level2 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
               $numbering{$letter_tag}++;
               create_or_replace_tag($feature_level2, 'ID', $newID_level2);
@@ -465,7 +477,9 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
                       }
 
                       my $letter_tag = get_letter_tag($primary_tag_level3);
-                      if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag} = $nbIDstart;}
+                      if (! exists_keys(\%numbering,($letter_tag))) {
+                        $numbering{$letter_tag} = $nbIDstart;
+                      }
                       my $newID_level3 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
                       if ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) {
                         if ($opt_nameU) {
@@ -552,8 +566,8 @@ if ($opt_InterproFile) {
     $listOfFunction .= "$funct,";
   }
   chop $listOfFunction;
-  my $nbGeneWithoutFunction= keys %geneWithoutFunction;
-  my $nbGeneWithFunction= keys %geneWithFunction;
+  my $nbGeneWithoutFunction = keys %geneWithoutFunction;
+  my $nbGeneWithFunction = keys %geneWithFunction;
   $stringPrint .= "nb mRNA without Functional annotation ($listOfFunction) = $nbmRNAwithoutFunction\n".
                   "nb mRNA with Functional annotation ($listOfFunction) = $nbmRNAwithFunction\n".
                   "nb gene without Functional annotation ($listOfFunction) = $nbGeneWithoutFunction\n".
@@ -610,7 +624,7 @@ print_omniscient($hash_omniscient, $ostreamGFF);
 
 
 #create or take the uniq letter TAG
-sub get_letter_tag{
+sub get_letter_tag {
   my ($tag) = @_;
 
   $tag = lc($tag);
@@ -619,7 +633,7 @@ sub get_letter_tag{
     my $substringLength = 1;
     my $letter = uc(substr($tag, 0, $substringLength));
 
-    while( grep( /^\Q$letter\E$/, @tag_list) ) { # to avoid duplicate
+    while ( grep( /^\Q$letter\E$/, @tag_list) ) { # to avoid duplicate
       $substringLength++;
       $letter = uc(substr($tag, 0, $substringLength));
     }
@@ -632,7 +646,7 @@ sub get_letter_tag{
 # each mRNA of a gene has its proper gene name. Most often is the same, and annie added a number at the end. To provide only one gene name, we remove this number and then remove duplicate name (case insensitive).
 # If it stay at the end of the process more than one name, they will be concatenated together.
 # It removes redundancy intra name.
-sub manageGeneNameBlast{
+sub manageGeneNameBlast {
 
   my ($geneName) = @_;
   foreach my $element (keys %$geneName) {
@@ -657,7 +671,9 @@ sub manageGeneNameBlast{
           $finalName .= "$name";
           $cpt++;
         }
-        else {$finalName .= "_$name"}
+        else {
+          $finalName .= "_$name";
+        }
 
     }
     $geneName->{$element} = $finalName;
@@ -666,7 +682,7 @@ sub manageGeneNameBlast{
 }
 
 # creates gene ID correctly formated (PREFIX,TYPE,NUMBER) like HOMSAPG00000000001 for a Homo sapiens gene.
-sub manageID{
+sub manageID {
   my ($prefix,$nbName,$type) = @_;
   my $result = "";
   my $numberNum = 11;
@@ -681,30 +697,30 @@ sub manageID{
 }
 
 # Create String containing the product information associated to the mRNA
-sub printProductFunct{
+sub printProductFunct {
   my ($refname) = @_;
   my $String = "";
   my $first = "yes";
   if (exists $mRNAproduct{$refname}) {
-    foreach my $element (@{$mRNAproduct{$refname}})
-    {
+    foreach my $element (@{$mRNAproduct{$refname}}) {
       if ($first eq "yes") {
         $String .= "$element";
         $first = "no";
       }
-      else {$String .= ",$element";}
+      else {
+        $String .= ",$element";
+      }
     }
   }
   return $String;
 }
 
-sub addFunctions{
+sub addFunctions {
   my ($feature, $opt_output) = @_;
 
   my $functionAdded = undef;
   my $ID = lc($feature->_tag_value('ID'));
   foreach my $function_type (keys %functionData) {
-
 
     if (exists ($functionData{$function_type}{$ID})) {
       $functionAdded = "true";
@@ -772,7 +788,9 @@ sub parse_blast {
               $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
             }
           }
-          else {$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if ($opt_verbose or $opt_output); }
+          else {
+            $ostreamLog->print("No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output);
+          }
         }
         else {
           $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if ($opt_verbose or $opt_output);
@@ -794,9 +812,13 @@ sub parse_blast {
             $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
           }
         }
-        else { $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output); }
+        else {
+          $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output);
+        }
       }
-      else { $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if ($opt_verbose or $opt_output);}
+      else {
+        $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if ($opt_verbose or $opt_output);
+      }
     }
   }
 
@@ -811,7 +833,8 @@ sub parse_blast {
 
   foreach my $l2 (keys %candidates) {
     if ( $candidates{$l2}[0] eq "error" ) {
-      $ostreamLog->print( "error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output); next;
+      $ostreamLog->print( "error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output);
+      next;
     }
 
     #Save uniprot id of the best match
@@ -849,9 +872,13 @@ sub parse_blast {
           push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
           push( @{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
         }
-        else { $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if ($opt_verbose or $opt_output); }
+        else {
+          $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if ($opt_verbose or $opt_output);
+        }
       }
-      else { $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if ($opt_verbose or $opt_output); }
+      else {
+        $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if ($opt_verbose or $opt_output);
+      }
       #} else {
       #  print "Nope\s".$candidates{$l2}[0]."\n";
     }
@@ -884,7 +911,9 @@ sub parse_blast {
           $cptmRNA++;
         }
       }
-      else {$mRNANameBlast{$mRNAList[0]} = $String;}
+      else {
+        $mRNANameBlast{$mRNAList[0]} = $String;
+      }
     }
     else { #in case where name was already used, we will modified it by addind a number like "_2"
       $nbDuplicateName++;
@@ -901,13 +930,15 @@ sub parse_blast {
           $cptmRNA++;
         }
       }
-      else {$mRNANameBlast{$mRNAList[0]} = $String;}
+      else {
+        $mRNANameBlast{$mRNAList[0]} = $String;
+      }
     }
   }
 }
 
 #uniprotHeader string spliter
-sub stringCatcher{
+sub stringCatcher {
   my($String) = @_;
   my $newString = undef;
 
@@ -915,7 +946,9 @@ sub stringCatcher{
     $newString = substr $String, length($1)+1;
     return ($newString, $1);
   }
-  else { return (undef, $String); }
+  else {
+    return (undef, $String);
+  }
 }
 
 # method to parse Interpro file
@@ -952,7 +985,7 @@ sub parse_interpro_tsv {
       my $interpro_tuple = "InterPro:".$interpro_value;
       print "interpro dB: ".$interpro_tuple."\n" if ($opt_verbose);
 
-      if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {	#to avoid duplicate
+      if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
         $TotalTerm{$db_name}++;
         push ( @{$functionData{$db_name}{$mRNAID}} , $interpro_tuple );
         if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -297,8 +297,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
       # Clean NAME attribute
-      # JN: Why do we need to remove the Name tag?
-      # JN: Note: all entries have a Name tag for the debug example I'm using
+      # JN: Why do we need to remove the Name tag? Note: all entries have a Name tag for the debug example I'm using
       if ($feature_level1->has_tag('Name')) {
         $feature_level1->remove_tag('Name');
       }
@@ -330,11 +329,11 @@ if ($opt_BlastFile || $opt_InterproFile ) {
             $geneNameGiven{$nameToCompare}++;
           } # first time we have given this name
         }
-        else { # JN: Start DEBUG
-          if ($DEBUG > 1) {
-            create_or_replace_tag($feature_level1, 'Name', 'DEBUG_noname_in_blast_level1'); # JN: Debug output
-          } # End DEBUG
-        }
+        #else { # JN: Start DEBUG
+        #  if ($DEBUG > 1) {
+        #    create_or_replace_tag($feature_level1, 'Name', 'DEBUG_noname_in_blast_level1'); # JN: Debug output
+        #  }
+        #} # End DEBUG
       }
 
       #################
@@ -346,7 +345,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_key_level2}{$id_level1}} ) {
 
             my $level2_ID = lc($feature_level2->_tag_value('ID'));
-            print Dumper($level2_ID);warn "\n level2_ID (hit return to continue)\n" and getc(); # JN: tmp debug
 
             # Clean NAME attribute
             if ($feature_level2->has_tag('Name')) {
@@ -790,6 +788,8 @@ sub parse_blast {
 
   my %candidates;
 
+  my %HoH = (); # JN: Debug
+
   while(my $line = <$file_in>) {
     my @values = split(/\t/, $line);
     my $l2_name = lc($values[0]);  # JN: maker-Bi03_p1mp_000319F-est_gff_StringTie-gene-5.8-mRNA-1
@@ -803,6 +803,10 @@ sub parse_blast {
     #if does not exist fill it if over the minimum evalue
     if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}} > 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
+
+        my $gn_presence = $fasta_id_gn_hash{lc($prot_name)}; # JN: Debug
+        $HoH{$l2_name}{$gn_presence}++; # JN: Debug
+
         my $protID_correct = undef;
 
         if ( exists $allIDs{lc($prot_name)}) { # JN: Look for same entry as in fasta file
@@ -842,6 +846,10 @@ sub parse_blast {
       } # JN: End DEBUG
     }
     elsif ( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
+
+      my $gn_presence = $fasta_id_gn_hash{lc($prot_name)}; # JN: Debug
+      $HoH{$l2_name}{$gn_presence}++; # JN: Debug
+
       my $protID_correct = undef;
 
       if ( exists $allIDs{lc($prot_name)}) {
@@ -932,6 +940,10 @@ sub parse_blast {
       }
     }
   }
+
+  print Dumper(\%HoH);warn "\n HoH (hit return to continue)\n" and getc();
+
+
 
   ####################################################
   ####### Step 3 : Manage NAME final gene name ####### several isoforms could have different gene name reported. So we have to keep that information in some way to report only one STRING to gene name attribute of the gene feature.

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -22,16 +22,16 @@ my $opt_reffile;
 my $opt_output;
 my $opt_BlastFile;
 my $opt_InterproFile;
-my $opt_name=undef;
+my $opt_name = undef;
 my $opt_nameU;
-my $opt_verbose=undef;
+my $opt_verbose = undef;
 my $opt_help = 0;
-my $opt_blastEvalue=1e-6;
+my $opt_blastEvalue = 1e-6;
 my $opt_dataBase = undef;
 my $opt_pe = 5;
 my %numbering;
-my $nbIDstart=1;
-my $prefixName=undef;
+my $nbIDstart = 1;
+my $prefixName = undef;
 my %tag_hash;
 my @tag_list;
 # END PARAMETERS - OPTION
@@ -44,10 +44,10 @@ my %mRNAUniprotIDFromBlast;
 my %mRNAproduct;
 my %geneNameGiven;
 my %duplicateNameGiven;
-my $nbDuplicateNameGiven=0;
-my $nbDuplicateName=0;
-my $nbNamedGene=0;
-my $nbGeneNameInBlast=0;
+my $nbDuplicateNameGiven = 0;
+my $nbDuplicateName = 0;
+my $nbNamedGene = 0;
+my $nbGeneNameInBlast = 0;
 # END FOR FUNCTION BLAST#
 
 # FOR FUNCTIONS INTERPRO#
@@ -61,14 +61,14 @@ my %functionOutput;
 my %functionStreamOutput;
 my %geneWithoutFunction;
 my %geneWithFunction;
-my $nbmRNAwithoutFunction=0;
-my $nbmRNAwithFunction=0;
-my $nbGeneWithGOterm=0;
-my $nbTotalGOterm=0;
+my $nbmRNAwithoutFunction = 0;
+my $nbmRNAwithFunction = 0;
+my $nbGeneWithGOterm = 0;
+my $nbTotalGOterm = 0;
 # END FOR FUNCTION INTERPRO#
 
 # OPTION MANAGMENT
-my @copyARGV=@ARGV;
+my @copyARGV = @ARGV;
 if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
                   'b|blast=s' => \$opt_BlastFile,
                   'd|db=s' => \$opt_dataBase,
@@ -140,14 +140,14 @@ if (defined($opt_output) ) {
   }
   mkdir $opt_output;
 
-  $ostreamReport=IO::File->new(">".$opt_output."/report.txt" ) or
+  $ostreamReport = IO::File->new(">".$opt_output."/report.txt" ) or
   croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/report.txt", $! ));
 
   my $file_out_name = fileparse($opt_reffile);
-  $ostreamGFF=Bio::Tools::GFF->new(-file => ">$opt_output/$file_out_name", -gff_version => 3 ) or
+  $ostreamGFF = Bio::Tools::GFF->new(-file => ">$opt_output/$file_out_name", -gff_version => 3 ) or
   croak(sprintf( "Can not open '%s' for writing %s", $opt_output."/".$opt_reffile, $! ));
 
-  $ostreamLog=IO::File->new(">".$opt_output."/error.txt" ) or
+  $ostreamLog = IO::File->new(">".$opt_output."/error.txt" ) or
   croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/log.txt", $! ));
 }
 else {
@@ -163,13 +163,13 @@ else {
 my $stringPrint = strftime "%m/%d/%Y", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
 if ($opt_name) {
-  $prefixName=$opt_name;
+  $prefixName = $opt_name;
   $stringPrint .= "->IDs are changed using <$opt_name> as prefix.\nIn the case of discontinuous features (i.e. a single feature that exists over multiple genomic locations) the same ID may appear on multiple lines.".
   " All lines that share an ID collectively represent a signle feature.\n";
 }
 if ($opt_nameU) {
   $stringPrint .= "->IDs will be changed using <$opt_nameU> as prefix. Features that shared an ID collectively (e.g. CDS, UTRs, etc...) will now have each an uniq ID.\n";
-  $prefixName=$opt_nameU;
+  $prefixName = $opt_nameU;
 }
 
 
@@ -215,7 +215,7 @@ if (defined $opt_BlastFile) {
   $db = Bio::DB::Fasta->new($opt_dataBase);
   # save ID in lower case to avoid cast problems
   my @ids = $db->get_all_primary_ids;
-  foreach my $id (@ids) {$allIDs{lc($id)}=$id;}
+  foreach my $id (@ids) {$allIDs{lc($id)} = $id;}
   print_time("Parsing Finished\n\n");
   #print "id.".$id"\t";
 
@@ -237,7 +237,7 @@ if (defined $opt_InterproFile) {
           croak(
             sprintf( "Can not open '%s' for writing %s", $opt_output."/$type.txt", $! )
           );
-      $functionStreamOutput{$type}=$ostreamFunct;
+      $functionStreamOutput{$type} = $ostreamFunct;
     }
   }
 }
@@ -255,7 +255,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
     foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
 
-      my $feature_level1=$hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
+      my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
       #print $feature_level1."\n";
       # Clean NAME attribute
@@ -270,14 +270,14 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
           $nbNamedGene++;
 
           # Check name duplicated given
-          my $nameClean=$geneNameBlast{$id_level1};
+          my $nameClean = $geneNameBlast{$id_level1};
           $nameClean =~ s/_([2-9]{1}[0-9]*|[0-9]{2,})*$//;
 
           my $nameToCompare;
           if (exists ($nameBlast{$nameClean})) { # We check that is really a name where we added the suffix _1
-            $nameToCompare=$nameClean;
+            $nameToCompare = $nameClean;
           }
-          else {$nameToCompare=$geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
+          else {$nameToCompare = $geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
 
           if (exists ($geneNameGiven{$nameToCompare})) {
             $nbDuplicateNameGiven++; # track total
@@ -305,14 +305,14 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
             if ($opt_BlastFile) {
               # add gene Name
               if (exists ($mRNANameBlast{$level2_ID})) {
-                my $mRNABlastName=$mRNANameBlast{$level2_ID};
+                my $mRNABlastName = $mRNANameBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'Name', $mRNABlastName);
               }
-              my $productData=printProductFunct($level2_ID);
+              my $productData = printProductFunct($level2_ID);
 
               #add UniprotID attribute
               if (exists ($mRNAUniprotIDFromBlast{$level2_ID})) {
-                my $mRNAUniprotID=$mRNAUniprotIDFromBlast{$level2_ID};
+                my $mRNAUniprotID = $mRNAUniprotIDFromBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'uniprot_id', $mRNAUniprotID);
               }
 
@@ -338,7 +338,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
 
             # print function if option
             if ($opt_InterproFile) {
-              my $parentID=$feature_level2->_tag_value('Parent');
+              my $parentID = $feature_level2->_tag_value('Parent');
 
               if (addFunctions($feature_level2, $opt_output)) {
                 $nbmRNAwithFunction++;$geneWithFunction{$parentID}++;
@@ -369,7 +369,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
   my %hash_sortBySeq;
   foreach my $tag_level1 ( keys %{$hash_omniscient->{'level1'}}) {
     foreach my $level1_id ( keys %{$hash_omniscient->{'level1'}{$tag_level1}}) {
-      my $position=$hash_omniscient->{'level1'}{$tag_level1}{$level1_id}->seq_id;
+      my $position = $hash_omniscient->{'level1'}{$tag_level1}{$level1_id}->seq_id;
       push (@{$hash_sortBySeq{$position}{$tag_level1}}, $hash_omniscient->{'level1'}{$tag_level1}{$level1_id});
     }
   }
@@ -383,9 +383,9 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
     foreach my $primary_tag_level1 (sort {$a cmp $b} keys %{$hash_sortBySeq{$seqid}}) {
 
       foreach my $feature_level1 ( sort {$a->start <=> $b->start} @{$hash_sortBySeq{$seqid}{$primary_tag_level1}}) {
-        my $level1_ID=$feature_level1->_tag_value('ID');
+        my $level1_ID = $feature_level1->_tag_value('ID');
         my $id_level1 = lc($level1_ID);
-        my $newID_level1=undef;
+        my $newID_level1 = undef;
         #print_time( "Next gene $id_level1\n");
 
         #keep track of Maker ID
@@ -395,12 +395,12 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
 
         my $letter_tag = get_letter_tag($primary_tag_level1);
 
-        if (! exists_keys(\%numbering,($letter_tag ))) {$numbering{$letter_tag }=$nbIDstart;}
-        $newID_level1 = manageID($prefixName, $numbering{$letter_tag }, $letter_tag );
+        if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag} = $nbIDstart;}
+        $newID_level1 = manageID($prefixName, $numbering{$letter_tag}, $letter_tag );
         $numbering{$letter_tag }++;
         create_or_replace_tag($feature_level1, 'ID', $newID_level1);
 
-        $finalID{$feature_level1->_tag_value('ID')}=$newID_level1;
+        $finalID{$feature_level1->_tag_value('ID')} = $newID_level1;
         #################
         # == LEVEL 2 == #
         #################
@@ -410,7 +410,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
             foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_level2}{$id_level1}}) {
 
               my $level2_ID = $feature_level2->_tag_value('ID');
-              my $newID_level2=undef;
+              my $newID_level2 = undef;
 
               #keep track of Maker ID
               if ($opt_InterproFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
@@ -418,13 +418,13 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
               }
 
               my $letter_tag = get_letter_tag($primary_tag_level2);
-              if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag}=$nbIDstart;}
+              if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag} = $nbIDstart;}
               $newID_level2 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
               $numbering{$letter_tag}++;
               create_or_replace_tag($feature_level2, 'ID', $newID_level2);
               create_or_replace_tag($feature_level2, 'Parent', $newID_level1);
 
-              $finalID{$level2_ID}=$newID_level2;
+              $finalID{$level2_ID} = $newID_level2;
               #################
               # == LEVEL 3 == #
               #################
@@ -442,7 +442,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
                       }
 
                       my $letter_tag = get_letter_tag($primary_tag_level3);
-                      if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag}=$nbIDstart;}
+                      if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag} = $nbIDstart;}
                       my $newID_level3 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
                       if ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) {
                         if ($opt_nameU) {
@@ -455,7 +455,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
                       create_or_replace_tag($feature_level3, 'ID', $newID_level3);
                       create_or_replace_tag($feature_level3, 'Parent', $newID_level2);
 
-                      $finalID{$level3_ID}=$newID_level3;
+                      $finalID{$level3_ID} = $newID_level3;
                     }
                     #save the new l3 into the new l2 id name
                     $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($newID_level2)} = delete $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)} # delete command return the value before deteling it, so we just transfert the value
@@ -491,7 +491,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
 # first table name\tfunction
 if ($opt_output) {
   foreach my $function_type (keys %functionOutput) {
-    my $streamOutput=$functionStreamOutput{$function_type};
+    my $streamOutput = $functionStreamOutput{$function_type};
     foreach my $ID (keys %{$functionOutput{$function_type}}) {
 
       if ($opt_nameU || $opt_name ) {
@@ -526,7 +526,7 @@ if ($opt_InterproFile) {
   #RESUME TOTAL OF FUNCTION ATTACHED
   my $listOfFunction;
   foreach my $funct (sort keys %functionData) {
-    $listOfFunction.="$funct,";
+    $listOfFunction .= "$funct,";
   }
   chop $listOfFunction;
   my $nbGeneWithoutFunction= keys %geneWithoutFunction;
@@ -538,15 +538,15 @@ if ($opt_InterproFile) {
 }
 
 if ($opt_BlastFile) {
-  my $nbGeneDuplicated=keys %duplicateNameGiven;
-  $nbDuplicateNameGiven=$nbDuplicateNameGiven+$nbGeneDuplicated; # Until now we have counted only name in more, now we add the original name.
+  my $nbGeneDuplicated = keys %duplicateNameGiven;
+  $nbDuplicateNameGiven = $nbDuplicateNameGiven+$nbGeneDuplicated; # Until now we have counted only name in more, now we add the original name.
   $stringPrint .= "$nbGeneNameInBlast gene names have been retrieved in the blast file. $nbNamedGene gene names have been successfully inferred.\n".
   "Among them there are $nbGeneDuplicated names that are shared at least per two genes for a total of $nbDuplicateNameGiven genes.\n";
   # "We have $nbDuplicateName gene names duplicated ($nbDuplicateNameGiven - $nbGeneDuplicated).";
 
   #Lets keep track the duplicated names
   if ($opt_output) {
-    my $duplicatedNameOut=IO::File->new(">".$opt_output."/duplicatedNameFromBlast.txt" );
+    my $duplicatedNameOut = IO::File->new(">".$opt_output."/duplicatedNameFromBlast.txt" );
     foreach my $name (sort { $duplicateNameGiven{$b} <=> $duplicateNameGiven{$a} } keys %duplicateNameGiven) {
       print $duplicatedNameOut "$name\t".($duplicateNameGiven{$name}+1)."\n";
     }
@@ -588,19 +588,19 @@ print_omniscient($hash_omniscient, $ostreamGFF);
 
 #create or take the uniq letter TAG
 sub get_letter_tag{
-  my ($tag)=@_;
+  my ($tag) = @_;
 
   $tag = lc($tag);
   if (! exists_keys (\%tag_hash,( $tag ))) {
 
-    my $substringLength=1;
+    my $substringLength = 1;
     my $letter = uc(substr($tag, 0, $substringLength));
 
     while( grep( /^\Q$letter\E$/, @tag_list) ) { # to avoid duplicate
       $substringLength++;
       $letter = uc(substr($tag, 0, $substringLength));
     }
-    $tag_hash{ $tag }=uc($letter);
+    $tag_hash{ $tag } = uc($letter);
     push(@tag_list, $letter)
   }
   return $tag_hash{ $tag };
@@ -611,9 +611,9 @@ sub get_letter_tag{
 # It removes redundancy intra name.
 sub manageGeneNameBlast{
 
-  my ($geneName)=@_;
+  my ($geneName) = @_;
   foreach my $element (keys %$geneName) {
-    my @tab=@{$geneName->{$element}};
+    my @tab = @{$geneName->{$element}};
 
     my %seen;
     my @unique;
@@ -626,79 +626,79 @@ sub manageGeneNameBlast{
       push(@unique, $w);
     }
 
-    my $finalName="";
-    my $cpt=0;
+    my $finalName = "";
+    my $cpt = 0;
     foreach my $name (@unique) { #if several name we will concatenate them together
 
         if ($cpt == 0) {
-          $finalName .="$name";
+          $finalName .= "$name";
           $cpt++;
         }
-        else {$finalName .="_$name"}
+        else {$finalName .= "_$name"}
 
     }
-    $geneName->{$element}=$finalName;
+    $geneName->{$element} = $finalName;
     $nameBlast{lc($finalName)}++;
   }
 }
 
 # creates gene ID correctly formated (PREFIX,TYPE,NUMBER) like HOMSAPG00000000001 for a Homo sapiens gene.
 sub manageID{
-  my ($prefix,$nbName,$type)=@_;
-  my $result="";
-  my $numberNum=11;
-  my $GoodNum="";
+  my ($prefix,$nbName,$type) = @_;
+  my $result = "";
+  my $numberNum = 11;
+  my $GoodNum = "";
   for (my $i=0; $i<$numberNum-length($nbName); $i++) {
-    $GoodNum.="0";
+    $GoodNum .= "0";
   }
-  $GoodNum.=$nbName;
-  $result="$prefix$type$GoodNum";
+  $GoodNum .= $nbName;
+  $result = "$prefix$type$GoodNum";
 
   return $result;
 }
 
 # Create String containing the product information associated to the mRNA
 sub printProductFunct{
-  my ($refname)=@_;
-  my $String="";
-  my $first="yes";
+  my ($refname) = @_;
+  my $String = "";
+  my $first = "yes";
   if (exists $mRNAproduct{$refname}) {
     foreach my $element (@{$mRNAproduct{$refname}})
     {
       if ($first eq "yes") {
-        $String.="$element";
-        $first="no";
+        $String .= "$element";
+        $first = "no";
       }
-      else {$String.=",$element";}
+      else {$String .= ",$element";}
     }
   }
   return $String;
 }
 
 sub addFunctions{
-  my ($feature, $opt_output)=@_;
+  my ($feature, $opt_output) = @_;
 
-  my $functionAdded=undef;
-  my $ID=lc($feature->_tag_value('ID'));
+  my $functionAdded = undef;
+  my $ID = lc($feature->_tag_value('ID'));
   foreach my $function_type (keys %functionData) {
 
 
     if (exists ($functionData{$function_type}{$ID})) {
-      $functionAdded="true";
+      $functionAdded = "true";
 
       my $data_list;
 
       if (lc($function_type) eq "go") {
         foreach my $data (@{$functionData{$function_type}{$ID}}) {
           $feature->add_tag_value('Ontology_term', $data);
-          $data_list.="$data,";
+          $data_list .= "$data,";
           $functionDataAdded{$function_type}++;
         }
       }
       else {
         foreach my $data (@{$functionData{$function_type}{$ID}}) {
           $feature->add_tag_value('Dbxref', $data);
-          $data_list.="$data,";
+          $data_list .= "$data,";
           $functionDataAdded{$function_type}++;
         }
       }
@@ -706,7 +706,7 @@ sub addFunctions{
       if ($opt_output) {
           my $ID = $feature->_tag_value('ID');
           chop $data_list;
-          $functionOutput{$function_type}{$ID}=$data_list;
+          $functionOutput{$function_type}{$ID} = $data_list;
         }
     }
   }
@@ -735,30 +735,30 @@ sub parse_blast {
     #if does not exist fill it if over the minimum evalue
     if (! exists_keys(\%candidates,($l2_name)) or @{$candidates{$l2_name}}> 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
-        my $protID_correct=undef;
+        my $protID_correct = undef;
 
         if ( exists $allIDs{lc($prot_name)}) {
           $protID_correct = $allIDs{lc($prot_name)};
           my $header = $db->header( $protID_correct );
           if (! $header =~ m/GN=/) {
             $ostreamLog->print( "No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
-            $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
+            $candidates{$l2_name} = ["error", $evalue, $prot_name."-".$l2_name];
           }
           if ($header =~ /PE=([1-5])\s/) {
             if ($1 <= $opt_pe) {
-              $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
+              $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
             }
           }
           else {$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if ($opt_verbose or $opt_output); }
         }
         else {
           $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if ($opt_verbose or $opt_output);
-          $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
+          $candidates{$l2_name} = ["error", $evalue, $prot_name."-".$l2_name];
         }
       }
     }
     elsif ( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
-      my $protID_correct=undef;
+      my $protID_correct = undef;
 
       if ( exists $allIDs{lc($prot_name)}) {
         $protID_correct = $allIDs{lc($prot_name)};
@@ -768,7 +768,7 @@ sub parse_blast {
         }
         if ($header =~ /PE=([1-5])\s/) {
           if ($1 <= $opt_pe) {
-            $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
+            $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
           }
         }
         else { $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output); }
@@ -809,16 +809,16 @@ sub parse_blast {
 
       #deal with the rest
       my %hash_rest;
-      my $tuple=undef;
+      my $tuple = undef;
       while ($theRest) {
         ($theRest, $tuple) = stringCatcher($theRest);
         my ($type,$value) = split /=/,$tuple;
         #print "$protID: type:$type --- value:$value\n";
-        $hash_rest{lc($type)}=$value;
+        $hash_rest{lc($type)} = $value;
       }
 
       if (exists($hash_rest{"gn"})) {
-        $nameGene=$hash_rest{"gn"};
+        $nameGene = $hash_rest{"gn"};
 
         if (exists_keys ($hash_mRNAGeneLink,($l2)) ) {
           my $geneID = $hash_mRNAGeneLink->{$l2};
@@ -847,38 +847,38 @@ sub parse_blast {
   my %geneNewNameUsed;
   foreach my $geneID (keys %geneName) {
     $nbGeneNameInBlast++;
-    my @mRNAList=@{$linkBmRNAandGene{$geneID}};
+    my @mRNAList = @{$linkBmRNAandGene{$geneID}};
     my $String = $geneName{$geneID};
     #print "$String\n";
     if (! exists( $geneNewNameUsed{$String})) {
       $geneNewNameUsed{$String}++;
-      $geneNameBlast{$geneID}=$String;
+      $geneNameBlast{$geneID} = $String;
       # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
-      my $cptmRNA=1;
+      my $cptmRNA = 1;
       if ($#mRNAList != 0) {
         foreach my $mRNA (@mRNAList) {
-          $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
+          $mRNANameBlast{$mRNA} = $String."_iso".$cptmRNA;
           $cptmRNA++;
         }
       }
-      else {$mRNANameBlast{$mRNAList[0]}=$String;}
+      else {$mRNANameBlast{$mRNAList[0]} = $String;}
     }
     else { #in case where name was already used, we will modified it by addind a number like "_2"
       $nbDuplicateName++;
       $geneNewNameUsed{$String}++;
-      my $nbFound=$geneNewNameUsed{$String};
-      $String.="_$nbFound";
+      my $nbFound = $geneNewNameUsed{$String};
+      $String .= "_$nbFound";
       $geneNewNameUsed{$String}++;
-      $geneNameBlast{$geneID}=$String;
+      $geneNameBlast{$geneID} = $String;
       # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
-      my $cptmRNA=1;
+      my $cptmRNA = 1;
       if ($#mRNAList != 0) {
         foreach my $mRNA (@mRNAList) {
-          $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
+          $mRNANameBlast{$mRNA} = $String."_iso".$cptmRNA;
           $cptmRNA++;
         }
       }
-      else {$mRNANameBlast{$mRNAList[0]}=$String;}
+      else {$mRNANameBlast{$mRNAList[0]} = $String;}
     }
   }
 }
@@ -886,7 +886,7 @@ sub parse_blast {
 #uniprotHeader string spliter
 sub stringCatcher{
   my($String) = @_;
-  my $newString=undef;
+  my $newString = undef;
 
   if ( $String =~ m/(\w{2}=.+?(?= \w{2}=))(.+)/ ) {
     $newString = substr $String, length($1)+1;
@@ -904,12 +904,12 @@ sub parse_interpro_tsv {
 
     my @values = split(/\t/, $line);
     my $sizeList = @values;
-    my $mRNAID=lc($values[0]);
+    my $mRNAID = lc($values[0]);
 
     #Check for the specific DB
-    my $db_name=$values[3];
-    my $db_value=$values[4];
-    my $db_tuple=$db_name.":".$db_value;
+    my $db_name = $values[3];
+    my $db_value = $values[4];
+    my $db_tuple = $db_name.":".$db_value;
     print "Specific dB: ".$db_tuple."\n" if ($opt_verbose);
 
     if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
@@ -923,9 +923,9 @@ sub parse_interpro_tsv {
 
     #check for interpro
     if ( $sizeList>11 ) {
-      my $db_name="InterPro";
-      my $interpro_value=$values[11];
-      $interpro_value=~ s/\n//g;
+      my $db_name = "InterPro";
+      my $interpro_value = $values[11];
+      $interpro_value =~ s/\n//g;
       my $interpro_tuple = "InterPro:".$interpro_value;
       print "interpro dB: ".$interpro_tuple."\n" if ($opt_verbose);
 
@@ -941,9 +941,9 @@ sub parse_interpro_tsv {
 
     #check for GO
     if ( $sizeList>13 ) {
-      my $db_name="GO";
+      my $db_name = "GO";
       my $go_flat_list = $values[13];
-      $go_flat_list=~ s/\n//g;
+      $go_flat_list =~ s/\n//g;
       my @go_list = split(/\|/,$go_flat_list); #cut at character |
       foreach my $go_tuple (@go_list) {
         print "GO term: ".$go_tuple."\n" if ($opt_verbose);
@@ -962,8 +962,8 @@ sub parse_interpro_tsv {
     #check for pathway
     if ( $sizeList>14 ) {
       my $pathway_flat_list = $values[14];
-      $pathway_flat_list=~ s/\n//g;
-      $pathway_flat_list=~ s/ //g;
+      $pathway_flat_list =~ s/\n//g;
+      $pathway_flat_list =~ s/ //g;
       my @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
       foreach my $pathway_tuple (@pathway_list) {
         my @tuple = split(/:/,$pathway_tuple); #cut at character :

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -231,15 +231,15 @@ my %allIDs;
 
 if (defined $opt_BlastFile) {
   # read fasta file and save info in memory
-  print ("look at the fasta database\n");
+  print_time("Look at the fasta database\n");
   $db = Bio::DB::Fasta->new($opt_dataBase);
   # save ID in lower case to avoid cast problems
   #my @ids = $db->get_all_primary_ids;
   #foreach my $id (@ids) {
   #  $allIDs{lc($id)} = $id;
   #}
-  # JN: Alternative parsing of fasta. Picking up GNs as we go
   # JN: Begin parse fasta
+  # JN: Alternative parsing of fasta. Picking up GNs as we go
   my $dbstream = $db->get_PrimarySeq_stream;
   while (my $seqobj = $dbstream->next_seq) {
     my $display_id = $seqobj->display_id;
@@ -249,14 +249,13 @@ if (defined $opt_BlastFile) {
     if ($desc =~ /GN=(\S+)/) {
         my $GN = $1;
         my $lc_GN = lc($GN);
-        $fasta_id_gn_hash{$lc_display_id} = $lc_GN;
+        $fasta_id_gn_hash{$lc_display_id} = $lc_GN; # JN: 'sp|a6w1c3|hem1_marms' => 'hema'
     }
     else {
       $nbGnNotPresentInDb++;
-      $fasta_id_gn_hash{$lc_display_id} = undef;
+      $fasta_id_gn_hash{$lc_display_id} = undef; # JN: 'sp|q8jfe6|bm8a_bommx' => undef
     }
   } # JN: End parse fasta
-  print Dumper(\%fasta_id_gn_hash);warn "\n fasta_id_gn_hash (hit return to continue)\n" and getc();
 
   print_time("Parsing Finished\n\n");
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -883,10 +883,7 @@ sub parse_blast {
   my %linkBmRNAandGene;
 
   foreach my $l2 (keys %candidates) {
-    print Dumper($l2);warn "\n l2 (hit return to continue)\n" and getc(); # JN: debug ons  2 jun 2021 18:22:56
-    print Dumper($candidates{$l2}[0]);warn "\n candidates l2 0 header (hit return to continue)\n" and getc(); # JN:  debug ons  2 jun 2021 18:22:56
-    print Dumper($candidates{$l2}[1]);warn "\n candidates l2 1 evalue (hit return to continue)\n" and getc(); # JN:  debug ons  2 jun 2021 18:22:56
-    print Dumper($candidates{$l2}[2]);warn "\n candidates l2 2 uniprot_id (hit return to continue)\n" and getc(); # JN:  debug ons  2 jun 2021 18:22:56
+    # JN: Here we need to not(?) return error above to be able to differentiate the cases without GN?
     if ( $candidates{$l2}[0] eq "error" ) {
       $ostreamLog->print("error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output);
       next;

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -576,7 +576,7 @@ if ($opt_InterproFile) {
   my $lineB =      "_________________________________________________________________________________________________________________________________";
   $stringPrint .= " ".$lineB."\n";
   $stringPrint .= "|                         | Nb Total term           | Nb mRNA with term       | Nb mRNA updated by term | Nb gene updated by term |\n";
-  $stringPrint .= "|                         | in raw File             |   in raw File           | in our annotation file  | in our annotation file  |\n";
+  $stringPrint .= "|                         | in raw File             | in raw File             | in our annotation file  | in our annotation file  |\n";
   $stringPrint .= "|".$lineB."|\n";
 
   foreach my $type (sort keys %functionData) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -294,9 +294,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
 
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
     foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
-
-      print Dumper($id_level1);warn "\n id_level1 (hit return to continue)\n" and getc(); # JN: tmp debug print
-
       my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
       # Clean NAME attribute

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -274,13 +274,13 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
           if (exists ($nameBlast{$nameClean})) { # We check that is really a name where we added the suffix _1
             $nameToCompare=$nameClean;
           }
-          else{$nameToCompare=$geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
+          else {$nameToCompare=$geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
 
           if (exists ($geneNameGiven{$nameToCompare})) {
             $nbDuplicateNameGiven++; # track total
             $duplicateNameGiven{$nameToCompare}++; # track diversity
           }
-          else{$geneNameGiven{$nameToCompare}++;} # first time we have given this name
+          else {$geneNameGiven{$nameToCompare}++;} # first time we have given this name
         }
       }
 
@@ -318,7 +318,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
                 if ($feature_level2->has_tag('pseudo')) {
                   create_or_replace_tag($feature_level2, 'Note', "product:$productData");
                 }
-                else{
+                else {
                   create_or_replace_tag($feature_level2, 'product', $productData);
                 }
               }
@@ -326,7 +326,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
                 if ($feature_level2->has_tag('pseudo')) {
                   create_or_replace_tag($feature_level2, 'Note', "product:hypothetical protein");
                 }
-                else{
+                else {
                   create_or_replace_tag($feature_level2, 'product', "hypothetical protein");
                 }
 
@@ -343,7 +343,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
                   delete $geneWithoutFunction{$parentID};
                 }
               }
-              else{
+              else {
                 $nbmRNAwithoutFunction++;
                 if (! exists ($geneWithFunction{$parentID})) {
                   $geneWithoutFunction{$parentID}++;
@@ -446,7 +446,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
                           $numbering{$letter_tag}++;
                         }
                       }
-                      else{
+                      else {
                         $numbering{$letter_tag}++;
                       }
                       create_or_replace_tag($feature_level3, 'ID', $newID_level3);
@@ -494,7 +494,7 @@ if ($opt_output) {
       if ($opt_nameU || $opt_name ) {
         print $streamOutput $finalID{$ID}."\t".$functionOutput{$function_type}{$ID}."\n";
       }
-      else{
+      else {
         print $streamOutput $ID."\t".$functionOutput{$function_type}{$ID}."\n";
       }
     }
@@ -631,7 +631,7 @@ sub manageGeneNameBlast{
           $finalName .="$name";
           $cpt++;
         }
-        else{$finalName .="_$name"}
+        else {$finalName .="_$name"}
 
     }
     $geneName->{$element}=$finalName;
@@ -666,7 +666,7 @@ sub printProductFunct{
         $String.="$element";
         $first="no";
       }
-      else{$String.=",$element";}
+      else {$String.=",$element";}
     }
   }
   return $String;
@@ -692,7 +692,7 @@ sub addFunctions{
           $functionDataAdded{$function_type}++;
         }
       }
-      else{
+      else {
         foreach my $data (@{$functionData{$function_type}{$ID}}) {
           $feature->add_tag_value('Dbxref', $data);
           $data_list.="$data,";
@@ -746,9 +746,9 @@ sub parse_blast {
               $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
             }
           }
-          else{$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if ($opt_verbose or $opt_output); }
+          else {$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if ($opt_verbose or $opt_output); }
         }
-        else{
+        else {
           $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if ($opt_verbose or $opt_output);
           $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
         }
@@ -768,9 +768,9 @@ sub parse_blast {
             $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
           }
         }
-        else{ $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output); }
+        else { $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output); }
       }
-      else{ $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if ($opt_verbose or $opt_output);}
+      else { $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if ($opt_verbose or $opt_output);}
     }
   }
 
@@ -823,10 +823,10 @@ sub parse_blast {
           push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
           push( @{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
         }
-        else{ $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if ($opt_verbose or $opt_output); }
+        else { $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if ($opt_verbose or $opt_output); }
       }
-      else{ $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if ($opt_verbose or $opt_output); }
-      #}else{
+      else { $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if ($opt_verbose or $opt_output); }
+      #} else {
       #  print "Nope\s".$candidates{$l2}[0]."\n";
     }
   }
@@ -858,9 +858,9 @@ sub parse_blast {
           $cptmRNA++;
         }
       }
-      else{$mRNANameBlast{$mRNAList[0]}=$String;}
+      else {$mRNANameBlast{$mRNAList[0]}=$String;}
     }
-    else{ #in case where name was already used, we will modified it by addind a number like "_2"
+    else { #in case where name was already used, we will modified it by addind a number like "_2"
       $nbDuplicateName++;
       $geneNewNameUsed{$String}++;
       my $nbFound=$geneNewNameUsed{$String};
@@ -875,7 +875,7 @@ sub parse_blast {
           $cptmRNA++;
         }
       }
-      else{$mRNANameBlast{$mRNAList[0]}=$String;}
+      else {$mRNANameBlast{$mRNAList[0]}=$String;}
     }
   }
 }
@@ -889,7 +889,7 @@ sub stringCatcher{
     $newString = substr $String, length($1)+1;
     return ($newString, $1);
   }
-  else{ return (undef, $String); }
+  else { return (undef, $String); }
 }
 
 # method to parse Interpro file

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -13,7 +13,7 @@ use Bio::DB::Fasta;
 use Bio::Tools::GFF;
 use AGAT::Omniscient;
 
-#use Data::Dumper; # JN: for dedug printing
+#use Data::Dumper; # JN: for dedug printing 
 my $DEBUG = 0;    # JN: for dedug printing
 
 my $header = get_agat_header();

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -252,11 +252,12 @@ if (defined $opt_BlastFile) {
         $fasta_id_gn_hash{$lc_display_id} = $lc_GN;
     }
     else {
-      #$missing_gn_in_fasta_counter++;
       $nbGnNotPresentInDb++;
       $fasta_id_gn_hash{$lc_display_id} = undef;
     }
   } # JN: End parse fasta
+  print Dumper(\%fasta_id_gn_hash);warn "\n fasta_id_gn_hash (hit return to continue)\n" and getc();
+
   print_time("Parsing Finished\n\n");
 
   # parse blast output
@@ -375,7 +376,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
               else {
                 create_or_replace_tag($feature_level2, 'gn_present', 'NA') if ($opt_addGnPresentTag);
               }
-
 
               #add product attribute
               if ($productData ne "") {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -70,7 +70,7 @@ if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
                   'b|blast=s' => \$opt_BlastFile,
                   'd|db=s' => \$opt_dataBase,
                   'be|blast_evalue=i' => \$opt_blastEvalue,
-		              'pe=i' => \$opt_pe,
+                  'pe=i' => \$opt_pe,
                   'i|interpro=s' => \$opt_InterproFile,
                   'id=s' => \$opt_name,
                   'idau=s' => \$opt_nameU,
@@ -104,7 +104,7 @@ if ( ! (defined($opt_reffile)) ){
 #################################################
 
 if($opt_pe>5 or $opt_pe<1){
-	print "Error the Protein Existence (PE) value must be between 1 and 5\n";exit;
+  print "Error the Protein Existence (PE) value must be between 1 and 5\n";exit;
 }
 
 my $streamBlast = IO::File->new();
@@ -193,9 +193,12 @@ print_time("Parsing Finished");
 
 #Print directly what has been read
 print_time("Compute statistics");
-print_omniscient_statistics ({ input => $hash_omniscient,
-															 output => $ostreamReport
-														 });
+print_omniscient_statistics(
+  {
+    input => $hash_omniscient,
+    output => $ostreamReport
+  }
+);
 
 ################################
 # MANAGE FUNCTIONAL INPUT FILE #
@@ -687,14 +690,14 @@ sub addFunctions{
         foreach my $data (@{$functionData{$function_type}{$ID}}){
           $feature->add_tag_value('Ontology_term', $data);
           $data_list.="$data,";
-	  $functionDataAdded{$function_type}++;
+          $functionDataAdded{$function_type}++;
         }
       }
       else{
         foreach my $data (@{$functionData{$function_type}{$ID}}){
           $feature->add_tag_value('Dbxref', $data);
           $data_list.="$data,";
-	  $functionDataAdded{$function_type}++;
+          $functionDataAdded{$function_type}++;
         }
       }
 
@@ -733,23 +736,23 @@ sub parse_blast {
         my $protID_correct=undef;
 
         if( exists $allIDs{lc($prot_name)}){
-        	$protID_correct = $allIDs{lc($prot_name)};
-        	my $header = $db->header( $protID_correct );
+          $protID_correct = $allIDs{lc($prot_name)};
+          my $header = $db->header( $protID_correct );
           if (! $header =~ m/GN=/){
             $ostreamLog->print( "No gene name (GN=) in this header $header\n") if($opt_verbose or $opt_output);
             $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
           }
-      		if($header =~ /PE=([1-5])\s/){
-    				if($1 <= $opt_pe){
-    					$candidates{$l2_name}=[$header, $evalue, $uniprot_id];
-      			}
-      		}
-      		else{$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if($opt_verbose or $opt_output); }
-      	}
-      	else{
-      		$ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if($opt_verbose or $opt_output);
-      		$candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
-      	}
+          if($header =~ /PE=([1-5])\s/){
+            if($1 <= $opt_pe){
+              $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
+            }
+          }
+          else{$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if($opt_verbose or $opt_output); }
+        }
+        else{
+          $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if($opt_verbose or $opt_output);
+          $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
+        }
       }
     }
     elsif( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
@@ -768,7 +771,7 @@ sub parse_blast {
         }
         else{ $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if($opt_verbose or $opt_output); }
       }
-	    else{ $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if($opt_verbose or $opt_output);}
+      else{ $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if($opt_verbose or $opt_output);}
     }
   }
 
@@ -794,38 +797,38 @@ sub parse_blast {
     print "header: ".$header."\n" if($opt_verbose);
 
     if ($header =~ m/(^[^\s]+)\s(.+?(?= \w{2}=))(.+)/){
-	    my $protID = $1;
-	    my $description = $2;
-	    my $theRest = $3;
-	    $theRest =~ s/\n//g;
-	    $theRest =~ s/\r//g;
-	    my $nameGene = undef;
-	    push ( @{ $mRNAproduct{$l2} }, $description );
+      my $protID = $1;
+      my $description = $2;
+      my $theRest = $3;
+      $theRest =~ s/\n//g;
+      $theRest =~ s/\r//g;
+      my $nameGene = undef;
+      push ( @{ $mRNAproduct{$l2} }, $description );
 
- 	    #deal with the rest
-	    my %hash_rest;
-	    my $tuple=undef;
-	    while ($theRest){
+      #deal with the rest
+      my %hash_rest;
+      my $tuple=undef;
+      while ($theRest){
         ($theRest, $tuple) = stringCatcher($theRest);
         my ($type,$value) = split /=/,$tuple;
-		    #print "$protID: type:$type --- value:$value\n";
-		    $hash_rest{lc($type)}=$value;
-	    }
+        #print "$protID: type:$type --- value:$value\n";
+        $hash_rest{lc($type)}=$value;
+      }
 
       if(exists($hash_rest{"gn"})){
-		    $nameGene=$hash_rest{"gn"};
+        $nameGene=$hash_rest{"gn"};
 
-		    if(exists_keys ($hash_mRNAGeneLink,($l2)) ){
-			    my $geneID = $hash_mRNAGeneLink->{$l2};
-	       	#print "push $geneID $nameGene\n";
-			    push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
-	        push( @{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
-		    }
-		    else{ $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if($opt_verbose or $opt_output); }
-	    }
-	    else{ $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if($opt_verbose or $opt_output); }
-  #  }else{
-  #    print "Nope\s".$candidates{$l2}[0]."\n";
+        if(exists_keys ($hash_mRNAGeneLink,($l2)) ){
+          my $geneID = $hash_mRNAGeneLink->{$l2};
+          #print "push $geneID $nameGene\n";
+          push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
+          push( @{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
+        }
+        else{ $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if($opt_verbose or $opt_output); }
+      }
+      else{ $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if($opt_verbose or $opt_output); }
+      #}else{
+      #  print "Nope\s".$candidates{$l2}[0]."\n";
     }
   }
 
@@ -886,7 +889,7 @@ sub stringCatcher{
 
     if ( $String =~ m/(\w{2}=.+?(?= \w{2}=))(.+)/ ) {
         $newString = substr $String, length($1)+1;
-    	return ($newString, $1);
+        return ($newString, $1);
     }
     else{ return (undef, $String); }
 }
@@ -902,80 +905,80 @@ sub parse_interpro_tsv {
     my $sizeList = @values;
     my $mRNAID=lc($values[0]);
 
-      #Check for the specific DB
-      my $db_name=$values[3];
-      my $db_value=$values[4];
-      my $db_tuple=$db_name.":".$db_value;
-      print "Specific dB: ".$db_tuple."\n" if($opt_verbose);
+    #Check for the specific DB
+    my $db_name=$values[3];
+    my $db_value=$values[4];
+    my $db_tuple=$db_name.":".$db_value;
+    print "Specific dB: ".$db_tuple."\n" if($opt_verbose);
 
-      if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {   #to avoid duplicate
-	      $TotalTerm{$db_name}++;
-	      push ( @{$functionData{$db_name}{$mRNAID}} , $db_tuple );
-	      if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
-	        $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
-	        $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
-	      }
-	}
-
-      #check for interpro
-      if( $sizeList>11 ){
-        my $db_name="InterPro";
-        my $interpro_value=$values[11];
-        $interpro_value=~ s/\n//g;
-	my $interpro_tuple = "InterPro:".$interpro_value;
-        print "interpro dB: ".$interpro_tuple."\n" if($opt_verbose);
-
-	if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {	#to avoid duplicate
-	        $TotalTerm{$db_name}++;
-	        push ( @{$functionData{$db_name}{$mRNAID}} , $interpro_tuple );
-	        if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
-	          $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
-	          $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
-	        }
-	}
+    if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {   #to avoid duplicate
+      $TotalTerm{$db_name}++;
+      push ( @{$functionData{$db_name}{$mRNAID}} , $db_tuple );
+      if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+        $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
+        $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
       }
+    }
 
-      #check for GO
-      if( $sizeList>13 ){
-        my $db_name="GO";
-        my $go_flat_list = $values[13];
-        $go_flat_list=~ s/\n//g;
-        my @go_list = split(/\|/,$go_flat_list); #cut at character |
-        foreach my $go_tuple (@go_list){
-          print "GO term: ".$go_tuple."\n" if($opt_verbose);
+    #check for interpro
+    if( $sizeList>11 ){
+      my $db_name="InterPro";
+      my $interpro_value=$values[11];
+      $interpro_value=~ s/\n//g;
+      my $interpro_tuple = "InterPro:".$interpro_value;
+      print "interpro dB: ".$interpro_tuple."\n" if($opt_verbose);
 
-	if (! grep( /^\Q$go_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
-	          $TotalTerm{$db_name}++;
-	          push ( @{$functionData{$db_name}{$mRNAID}} , $go_tuple );
-	          if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
-	            $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
-	            $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
-	          }
-	  }
+      if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {	#to avoid duplicate
+        $TotalTerm{$db_name}++;
+        push ( @{$functionData{$db_name}{$mRNAID}} , $interpro_tuple );
+        if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+          $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
+          $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
         }
       }
+    }
 
-      #check for pathway
-      if( $sizeList>14 ){
-        my $pathway_flat_list = $values[14];
-        $pathway_flat_list=~ s/\n//g;
-        $pathway_flat_list=~ s/ //g;
-        my  @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
-        foreach my $pathway_tuple (@pathway_list){
-          my @tuple = split(/:/,$pathway_tuple); #cut at character :
-          my $db_name = $tuple[0];
-          print "pathway info: ".$pathway_tuple."\n" if($opt_verbose);
+    #check for GO
+    if( $sizeList>13 ){
+      my $db_name="GO";
+      my $go_flat_list = $values[13];
+      $go_flat_list=~ s/\n//g;
+      my @go_list = split(/\|/,$go_flat_list); #cut at character |
+      foreach my $go_tuple (@go_list){
+        print "GO term: ".$go_tuple."\n" if($opt_verbose);
 
-	  if (! grep( /^\Q$pathway_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { # to avoid duplicate
-	          $TotalTerm{$db_name}++;
-	          push ( @{$functionData{$db_name}{$mRNAID}} , $pathway_tuple );
-	          if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
-	            $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
-	            $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
-	          }
-	  }
+        if (! grep( /^\Q$go_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
+          $TotalTerm{$db_name}++;
+          push ( @{$functionData{$db_name}{$mRNAID}} , $go_tuple );
+          if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+            $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
+            $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
+          }
         }
       }
+    }
+
+    #check for pathway
+    if( $sizeList>14 ){
+      my $pathway_flat_list = $values[14];
+      $pathway_flat_list=~ s/\n//g;
+      $pathway_flat_list=~ s/ //g;
+      my  @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
+      foreach my $pathway_tuple (@pathway_list){
+        my @tuple = split(/:/,$pathway_tuple); #cut at character :
+        my $db_name = $tuple[0];
+        print "pathway info: ".$pathway_tuple."\n" if($opt_verbose);
+
+        if (! grep( /^\Q$pathway_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { # to avoid duplicate
+          $TotalTerm{$db_name}++;
+          push ( @{$functionData{$db_name}{$mRNAID}} , $pathway_tuple );
+          if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+            $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
+            $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
+          }
+        }
+      }
+    }
   }
 }
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -579,7 +579,8 @@ if ($opt_InterproFile) {
   chop $listOfFunction;
   my $nbGeneWithoutFunction = keys %geneWithoutFunction;
   my $nbGeneWithFunction = keys %geneWithFunction;
-  $stringPrint .= "nb mRNA without Functional annotation ($listOfFunction) = $nbmRNAwithoutFunction\n".
+  $stringPrint .= "\n".
+                  "nb mRNA without Functional annotation ($listOfFunction) = $nbmRNAwithoutFunction\n".
                   "nb mRNA with Functional annotation ($listOfFunction) = $nbmRNAwithFunction\n".
                   "nb gene without Functional annotation ($listOfFunction) = $nbGeneWithoutFunction\n".
                   "nb gene with Functional annotation ($listOfFunction) = $nbGeneWithFunction\n";
@@ -588,10 +589,10 @@ if ($opt_InterproFile) {
 if ($opt_BlastFile) {
   my $nbGeneDuplicated = keys %duplicateNameGiven;
   $nbDuplicateNameGiven = $nbDuplicateNameGiven + $nbGeneDuplicated; # Until now we have counted only name in more, now we add the original name.
-  $stringPrint .= "$nbGeneNameInBlast gene names have been retrieved in the blast file. $nbNamedGene gene names have been successfully inferred.\n".
+  $stringPrint .= "\n$nbGeneNameInBlast gene names have been retrieved in the blast file. $nbNamedGene gene names have been successfully inferred.\n".
   "Among them there are $nbGeneDuplicated names that are shared at least per two genes for a total of $nbDuplicateNameGiven genes.\n";
   # "We have $nbDuplicateName gene names duplicated ($nbDuplicateNameGiven - $nbGeneDuplicated).";
-  $stringPrint .= "$missing_gn_in_fasta_counter entries in db have no GN\n"; # JN: Tentative output
+  $stringPrint .= "\n$missing_gn_in_fasta_counter entries in db have no GN\n"; # JN: Tentative output
 
   #Lets keep track the duplicated names
   if ($opt_output) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -804,8 +804,15 @@ sub parse_blast {
     if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}} > 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
 
-        my $gn_presence = $fasta_id_gn_hash{lc($prot_name)}; # JN: Debug HoH
-        $HoH{$l2_name}{$gn_presence}++; # JN: Debug HoH
+        my $lc_prot_name = lc($prot_name); # JN: Begin debug HoH
+        my $gn_presence = '';
+        if (exists($fasta_id_gn_hash{$lc_prot_name)}) {
+          $gn_presence = $fasta_id_gn_hash{$lc_prot_name};
+          $HoH{$l2_name}{$gn_presence}++;
+        }
+        else {
+          warn "\n$lc_prot_name not found in fasta_id_gn_hash (hit return to continue)\n" and getc();
+        } # JN: End Debug HoH
 
         my $protID_correct = undef;
 
@@ -847,8 +854,15 @@ sub parse_blast {
     }
     elsif ( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
 
-      my $gn_presence = $fasta_id_gn_hash{lc($prot_name)}; # JN: Debug
-      $HoH{$l2_name}{$gn_presence}++; # JN: Debug
+      my $lc_prot_name = lc($prot_name); # JN: begin Debug HoH
+      my $gn_presence = '';
+      if (exists($fasta_id_gn_hash{$lc_prot_name)}) {
+        $gn_presence = $fasta_id_gn_hash{$lc_prot_name};
+        $HoH{$l2_name}{$gn_presence}++;
+      }
+      else {
+        warn "\n$lc_prot_name not found in fasta_id_gn_hash (hit return to continue)\n" and getc();
+      }  # JN: End Debug HoH
 
       my $protID_correct = undef;
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -804,13 +804,13 @@ sub parse_blast {
 
       if ( $evalue <= $opt_blastEvalue ) {
         # JN: begin gene_name_Debug HoH
-        my $lc_prot_name = lc($prot_name);            # JN: sp|q4fzt2|ppme1_rat
-        if (exists($fasta_id_gn_hash{$l2_name})) {    # JN: Key exists if gene name or undef
-          if (defined($fasta_id_gn_hash{$l2_name})) { # JN: Only defined if gene name
-            my $gn = $fasta_id_gn_hash{$l2_name};     # JN: Get the gene name
-            $gene_name_HoH{$l2_name}{$gn}++;          # JN: Count the gene name
+        my $lc_prot_name = lc($prot_name);                 # JN: sp|q4fzt2|ppme1_rat
+        if (exists($fasta_id_gn_hash{$lc_prot_name})) {    # JN: Key exists if gene name or undef
+          if (defined($fasta_id_gn_hash{$lc_prot_name})) { # JN: Only defined if gene name
+            my $gn = $fasta_id_gn_hash{$lc_prot_name};     # JN: Get the gene name
+            $gene_name_HoH{$l2_name}{$gn}++;               # JN: Count the gene name
           }
-          else {                                      # JN: If not defined, the 'GN=' is missing
+          else {                                           # JN: If not defined, the 'GN=' is missing
             undef($gene_name_HoH{$lc_prot_name});
           }
         }

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -788,7 +788,7 @@ sub parse_blast {
 
   my %candidates;
 
-  my %HoH = (); # JN: Debug
+  my %HoH = (); # JN: Debug HoH
 
   while(my $line = <$file_in>) {
     my @values = split(/\t/, $line);
@@ -804,8 +804,8 @@ sub parse_blast {
     if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}} > 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
 
-        my $gn_presence = $fasta_id_gn_hash{lc($prot_name)}; # JN: Debug
-        $HoH{$l2_name}{$gn_presence}++; # JN: Debug
+        my $gn_presence = $fasta_id_gn_hash{lc($prot_name)}; # JN: Debug HoH
+        $HoH{$l2_name}{$gn_presence}++; # JN: Debug HoH
 
         my $protID_correct = undef;
 
@@ -941,7 +941,28 @@ sub parse_blast {
     }
   }
 
-  print Dumper(\%HoH);warn "\n HoH (hit return to continue)\n" and getc();
+  # JN: Next step: go through HoH and see if there are any level2 entries with any "DEBUG_missing_GN_in_db",
+  # JN: and if so, is "DEBUG_missing_GN_in_db" the only value?
+  # JN: tor  3 jun 2021 14:08:59
+  # JN: Begin gn_missing=yes|no|NA
+  my %l2_gn_missing_hash = (); # JN: Key: level2, value: gn_missing=yes
+  while ( my ($l2, $values) = each %HoH ) {
+    my $size = scalar(%{$values});
+    if ($size == 1) {
+      if (exists($HoH{$l2}{'DEBUG_missing_GN_in_db'})) {
+        $l2_gn_missing_hash{$l2} = "yes";
+      }
+      else {
+        $l2_gn_missing_hash{$l2} = "no";
+      }
+    }
+    else {
+      my (@vals) = keys (%{$values});
+        print "l2 $l2 have several values: @vals\n";
+    }
+  }
+  print Dumper(\%l2_gn_missing_hash);warn "\n l2_gn_missing_hash (hit return to continue)\n" and getc();
+  # JN: End gn_missing=yes|no|NA
 
 
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -351,18 +351,13 @@ if ($opt_BlastFile || $opt_InterproFile ) {
               $feature_level2->remove_tag('Name');
             }
 
-            #Manage Name if option set
+            # Manage Name if option set
             if ($opt_BlastFile) {
               # add gene Name
               if (exists ($mRNANameBlast{$level2_ID})) {
                 my $mRNABlastName = $mRNANameBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'Name', $mRNABlastName);
               }
-              else { # JN: Start DEBUG
-                if ($DEBUG) {
-                  create_or_replace_tag($feature_level2, 'Name', 'DEBUG_noname_level2'); # JN: Debug output
-                }
-              } # JN: End DEBUG
 
               my $productData = printProductFunct($level2_ID);
 
@@ -370,6 +365,15 @@ if ($opt_BlastFile || $opt_InterproFile ) {
               if (exists ($mRNAUniprotIDFromBlast{$level2_ID})) {
                 my $mRNAUniprotID = $mRNAUniprotIDFromBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'uniprot_id', $mRNAUniprotID);
+              }
+
+              # JN: Add info on missing GN in fasta header in blast db file
+              if (exists($l2_gn_missing_hash{$level2_ID})) { # JN: Check lower case or not!
+                my $gn_presence = $l2_gn_missing_hash{$level2_ID};
+                create_or_replace_tag($feature_level2, 'gn_missing', $gn_presence);
+              }
+              else {
+                create_or_replace_tag($feature_level2, 'gn_missing', 'NA');
               }
 
               #add product attribute
@@ -979,10 +983,8 @@ sub parse_blast {
         print "l2 $l2 have several values: @vals\n";
     }
   }
-  print Dumper(\%l2_gn_missing_hash);warn "\n l2_gn_missing_hash (hit return to continue)\n" and getc();
+  #print Dumper(\%l2_gn_missing_hash);warn "\n l2_gn_missing_hash (hit return to continue)\n" and getc();
   # JN: End gn_missing
-
-
 
   ####################################################
   ####### Step 3 : Manage NAME final gene name ####### several isoforms could have different gene name reported. So we have to keep that information in some way to report only one STRING to gene name attribute of the gene feature.

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -366,8 +366,11 @@ if ($opt_BlastFile || $opt_InterproFile ) {
               }
 
               # JN: Add info on existence of GN= tag in fasta header in blast db file: gn_present=yes|no|NA
-              if (exists($l2_gn_present_hash{$level2_ID})) {
+              print Dumper($level2_ID);warn "\n level2_ID before entering hash l2_gn_present_hash for setting status ( HERE (hit return to continue)\n" and getc();
+
+              if (exists($l2_gn_present_hash{$level2_ID})) { # JN: level2_ID: 
                 my $gn_status = $l2_gn_present_hash{$level2_ID};
+                print Dumper($gn_status);warn "\n gn_status for level2_ID: $level2_ID (hit return to continue)\n" and getc();
                 if ($gn_status eq 'no' ) {
                   $nbGnNotPresentForMrna++;
                 }
@@ -950,7 +953,7 @@ sub parse_blast {
   }
 
   # JN: Begin traversing gene_name_HoH, and populate global hash l2_gn_present_hash
-  while ( my ($l2_key, $values) = each %gene_name_HoH ) {
+  while ( my ($l2_key, $values) = each %gene_name_HoH ) { # Key: sp|q4fzt2|ppme1_rat , value: 
     my $size = 0;
     if (defined($values)) { # JN: If defined, we have at least one GN
       $size = scalar(%{$values});

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -806,7 +806,7 @@ sub parse_blast {
 
         my $lc_prot_name = lc($prot_name); # JN: Begin debug HoH
         my $gn_presence = '';
-        if (exists($fasta_id_gn_hash{$lc_prot_name)}) {
+        if (exists($fasta_id_gn_hash{$lc_prot_name})) {
           $gn_presence = $fasta_id_gn_hash{$lc_prot_name};
           $HoH{$l2_name}{$gn_presence}++;
         }
@@ -856,7 +856,7 @@ sub parse_blast {
 
       my $lc_prot_name = lc($prot_name); # JN: begin Debug HoH
       my $gn_presence = '';
-      if (exists($fasta_id_gn_hash{$lc_prot_name)}) {
+      if (exists($fasta_id_gn_hash{$lc_prot_name})) {
         $gn_presence = $fasta_id_gn_hash{$lc_prot_name};
         $HoH{$l2_name}{$gn_presence}++;
       }

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -74,29 +74,29 @@ if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
                   'i|interpro=s' => \$opt_InterproFile,
                   'id=s' => \$opt_name,
                   'idau=s' => \$opt_nameU,
-                  'nb=i'      => \$nbIDstart,
-                  'o|output=s'      => \$opt_output,
-                  'v'      => \$opt_verbose,
-                  'h|help!'         => \$opt_help ) )
+                  'nb=i' => \$nbIDstart,
+                  'o|output=s'  => \$opt_output,
+                  'v' => \$opt_verbose,
+                  'h|help!' => \$opt_help ) )
 {
-    pod2usage( { -message => 'Failed to parse command line',
-                 -verbose => 1,
-                 -exitval => 1 } );
+  pod2usage( { -message => 'Failed to parse command line',
+               -verbose => 1,
+               -exitval => 1 } );
 }
 
 # Print Help and exit
 if ($opt_help) {
-    pod2usage( { -verbose => 99,
-                 -exitval => 0,
-                 -message => "$header\n" } );
+  pod2usage( { -verbose => 99,
+               -exitval => 0,
+               -message => "$header\n" } );
 }
 
 if ( ! (defined($opt_reffile)) ) {
-    pod2usage( {
-           -message => "$header\nAt least 1 parameter is mandatory:\nInput reference gff file (--f)\n\n".
-           "Many optional parameters are available. Look at the help documentation to know more.\n",
-           -verbose => 0,
-           -exitval => 1 } );
+  pod2usage( {
+         -message => "$header\nAt least 1 parameter is mandatory:\nInput reference gff file (--f)\n\n".
+         "Many optional parameters are available. Look at the help documentation to know more.\n",
+         -verbose => 0,
+         -exitval => 1 } );
 }
 
 #################################################
@@ -130,10 +130,10 @@ my $ostreamGFF;
 my $ostreamLog;
 if (defined($opt_output) ) {
   if (-f $opt_output) {
-      print "Cannot create a directory with the name $opt_output because a file with this name already exists.\n";exit();
+    print "Cannot create a directory with the name $opt_output because a file with this name already exists.\n";exit();
   }
   if (-d $opt_output) {
-      print "The output directory choosen already exists. Please geve me another Name.\n";exit();
+    print "The output directory choosen already exists. Please geve me another Name.\n";exit();
   }
   mkdir $opt_output;
 
@@ -185,8 +185,7 @@ if ($opt_output) { print_time("$stringPrint");} # When ostreamReport is a file w
 
 ######################
 ### Parse GFF input #
-my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_reffile
-                                                              });
+my ($hash_omniscient, $hash_mRNAGeneLink) = slurp_gff3_file_JD({ input => $opt_reffile});
 print_time("Parsing Finished");
 ### END Parse GFF input #
 #########################
@@ -212,7 +211,7 @@ if (defined $opt_BlastFile) {
   print ("look at the fasta database\n");
   $db = Bio::DB::Fasta->new($opt_dataBase);
   # save ID in lower case to avoid cast problems
-  my @ids      = $db->get_all_primary_ids;
+  my @ids = $db->get_all_primary_ids;
   foreach my $id (@ids) {$allIDs{lc($id)}=$id;}
   print_time("Parsing Finished\n\n");
   #print "id.".$id"\t";
@@ -233,7 +232,7 @@ if (defined $opt_InterproFile) {
       my $ostreamFunct = IO::File->new();
       $ostreamFunct->open( $opt_output."/$type.txt", 'w' ) or
           croak(
-              sprintf( "Can not open '%s' for writing %s", $opt_output."/$type.txt", $! )
+            sprintf( "Can not open '%s' for writing %s", $opt_output."/$type.txt", $! )
           );
       $functionStreamOutput{$type}=$ostreamFunct;
     }
@@ -245,7 +244,7 @@ if (defined $opt_InterproFile) {
 ###########################
 # change FUNCTIONAL information if asked for
 if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFile) {
-    print_time( "load FUNCTIONAL information\n" );
+  print_time( "load FUNCTIONAL information\n" );
 
   #################
   # == LEVEL 1 == #
@@ -255,7 +254,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
 
       my $feature_level1=$hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
-  #    print $feature_level1."\n";
+      #print $feature_level1."\n";
       # Clean NAME attribute
       if ($feature_level1->has_tag('Name')) {
         $feature_level1->remove_tag('Name');
@@ -278,8 +277,8 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
           else{$nameToCompare=$geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
 
           if (exists ($geneNameGiven{$nameToCompare})) {
-              $nbDuplicateNameGiven++; # track total
-              $duplicateNameGiven{$nameToCompare}++; # track diversity
+            $nbDuplicateNameGiven++; # track total
+            $duplicateNameGiven{$nameToCompare}++; # track diversity
           }
           else{$geneNameGiven{$nameToCompare}++;} # first time we have given this name
         }
@@ -317,18 +316,18 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
               #add product attribute
               if ($productData ne "") {
                 if ($feature_level2->has_tag('pseudo')) {
-                    create_or_replace_tag($feature_level2, 'Note', "product:$productData");
+                  create_or_replace_tag($feature_level2, 'Note', "product:$productData");
                 }
                 else{
-                    create_or_replace_tag($feature_level2, 'product', $productData);
+                  create_or_replace_tag($feature_level2, 'product', $productData);
                 }
               }
               else {
                 if ($feature_level2->has_tag('pseudo')) {
-                    create_or_replace_tag($feature_level2, 'Note', "product:hypothetical protein");
+                  create_or_replace_tag($feature_level2, 'Note', "product:hypothetical protein");
                 }
                 else{
-                    create_or_replace_tag($feature_level2, 'product', "hypothetical protein");
+                  create_or_replace_tag($feature_level2, 'product', "hypothetical protein");
                 }
 
               } #Case where the protein is not known
@@ -458,7 +457,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
                     #save the new l3 into the new l2 id name
                     $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($newID_level2)} = delete $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)} # delete command return the value before deteling it, so we just transfert the value
                   }
-                  if ($opt_name and  ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) {
+                  if ($opt_name and mary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) {
                     my $letter_tag = get_letter_tag($primary_tag_level3);
                     $numbering{$letter_tag}++;
                   } # with this option we increment UTR name only for each UTR (cds also)
@@ -493,10 +492,10 @@ if ($opt_output) {
     foreach my $ID (keys %{$functionOutput{$function_type}}) {
 
       if ($opt_nameU || $opt_name ) {
-        print $streamOutput  $finalID{$ID}."\t".$functionOutput{$function_type}{$ID}."\n";
+        print $streamOutput $finalID{$ID}."\t".$functionOutput{$function_type}{$ID}."\n";
       }
       else{
-        print $streamOutput  $ID."\t".$functionOutput{$function_type}{$ID}."\n";
+        print $streamOutput $ID."\t".$functionOutput{$function_type}{$ID}."\n";
       }
     }
   }
@@ -594,7 +593,7 @@ sub get_letter_tag{
     my $substringLength=1;
     my $letter = uc(substr($tag, 0, $substringLength));
 
-    while(  grep( /^\Q$letter\E$/, @tag_list) ) { # to avoid duplicate
+    while( grep( /^\Q$letter\E$/, @tag_list) ) { # to avoid duplicate
       $substringLength++;
       $letter = uc(substr($tag, 0, $substringLength));
     }
@@ -618,7 +617,7 @@ sub manageGeneNameBlast{
     for my $w (@tab) { # remove duplicate in list case insensitive
       $w =~ s/_[0-9]+$// ;
 
-#      print "w".$w."\t";
+      #print "w".$w."\t";
 
       next if $seen{lc($w)}++;
       push(@unique, $w);
@@ -626,7 +625,7 @@ sub manageGeneNameBlast{
 
     my $finalName="";
     my $cpt=0;
-    foreach my $name (@unique) {  #if several name we will concatenate them together
+    foreach my $name (@unique) { #if several name we will concatenate them together
 
         if ($cpt == 0) {
           $finalName .="$name";
@@ -720,7 +719,7 @@ sub parse_blast {
 
   my %candidates;
 
-  while( my $line = <$file_in>)  {
+  while( my $line = <$file_in>) {
     my @values = split(/\t/, $line);
     my $l2_name = lc($values[0]);
     my $prot_name = $values[1];
@@ -836,62 +835,61 @@ sub parse_blast {
   ####### Step 3 : Manage NAME final gene name ####### several isoforms could have different gene name reported. So we have to keep that information in some way to report only one STRING to gene name attribute of the gene feature.
   ################# Remove redundancy to have only one name for each gene
 
-   manageGeneNameBlast(\%geneName);
+  manageGeneNameBlast(\%geneName);
 
 
   ##########################################################
   ####### Step 4 : CLEAN NAMES REDUNDANCY inter gene #######
 
-   my %geneNewNameUsed;
-   foreach my $geneID (keys %geneName) {
-     $nbGeneNameInBlast++;
-
-     my @mRNAList=@{$linkBmRNAandGene{$geneID}};
-     my $String = $geneName{$geneID};
- #    print "$String\n";
-     if (! exists( $geneNewNameUsed{$String})) {
-       $geneNewNameUsed{$String}++;
-       $geneNameBlast{$geneID}=$String;
-       # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
-       my $cptmRNA=1;
-       if ($#mRNAList != 0) {
-         foreach my $mRNA (@mRNAList) {
-           $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
-           $cptmRNA++;
-         }
-       }
-       else{$mRNANameBlast{$mRNAList[0]}=$String;}
-     }
-     else{ #in case where name was already used, we will modified it by addind a number like "_2"
-       $nbDuplicateName++;
-       $geneNewNameUsed{$String}++;
-       my $nbFound=$geneNewNameUsed{$String};
-       $String.="_$nbFound";
-       $geneNewNameUsed{$String}++;
-       $geneNameBlast{$geneID}=$String;
-       # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
-       my $cptmRNA=1;
-       if ($#mRNAList != 0) {
-         foreach my $mRNA (@mRNAList) {
-           $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
-           $cptmRNA++;
-         }
-       }
-       else{$mRNANameBlast{$mRNAList[0]}=$String;}
-     }
-   }
+  my %geneNewNameUsed;
+  foreach my $geneID (keys %geneName) {
+    $nbGeneNameInBlast++;
+    my @mRNAList=@{$linkBmRNAandGene{$geneID}};
+    my $String = $geneName{$geneID};
+    #print "$String\n";
+    if (! exists( $geneNewNameUsed{$String})) {
+      $geneNewNameUsed{$String}++;
+      $geneNameBlast{$geneID}=$String;
+      # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
+      my $cptmRNA=1;
+      if ($#mRNAList != 0) {
+        foreach my $mRNA (@mRNAList) {
+          $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
+          $cptmRNA++;
+        }
+      }
+      else{$mRNANameBlast{$mRNAList[0]}=$String;}
+    }
+    else{ #in case where name was already used, we will modified it by addind a number like "_2"
+      $nbDuplicateName++;
+      $geneNewNameUsed{$String}++;
+      my $nbFound=$geneNewNameUsed{$String};
+      $String.="_$nbFound";
+      $geneNewNameUsed{$String}++;
+      $geneNameBlast{$geneID}=$String;
+      # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
+      my $cptmRNA=1;
+      if ($#mRNAList != 0) {
+        foreach my $mRNA (@mRNAList) {
+          $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
+          $cptmRNA++;
+        }
+      }
+      else{$mRNANameBlast{$mRNAList[0]}=$String;}
+    }
+  }
 }
 
 #uniprotHeader string spliter
 sub stringCatcher{
-    my($String) = @_;
-    my $newString=undef;
+  my($String) = @_;
+  my $newString=undef;
 
-    if ( $String =~ m/(\w{2}=.+?(?= \w{2}=))(.+)/ ) {
-        $newString = substr $String, length($1)+1;
-        return ($newString, $1);
-    }
-    else{ return (undef, $String); }
+  if ( $String =~ m/(\w{2}=.+?(?= \w{2}=))(.+)/ ) {
+    $newString = substr $String, length($1)+1;
+    return ($newString, $1);
+  }
+  else{ return (undef, $String); }
 }
 
 # method to parse Interpro file
@@ -899,7 +897,7 @@ sub parse_interpro_tsv {
   my($file_in,$fileName) = @_;
   print( "Reading features from $fileName...\n");
 
-  while( my $line = <$file_in>)  {
+  while( my $line = <$file_in>) {
 
     my @values = split(/\t/, $line);
     my $sizeList = @values;
@@ -911,7 +909,7 @@ sub parse_interpro_tsv {
     my $db_tuple=$db_name.":".$db_value;
     print "Specific dB: ".$db_tuple."\n" if ($opt_verbose);
 
-    if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {   #to avoid duplicate
+    if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
       $TotalTerm{$db_name}++;
       push ( @{$functionData{$db_name}{$mRNAID}} , $db_tuple );
       if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
@@ -963,7 +961,7 @@ sub parse_interpro_tsv {
       my $pathway_flat_list = $values[14];
       $pathway_flat_list=~ s/\n//g;
       $pathway_flat_list=~ s/ //g;
-      my  @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
+      my @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
       foreach my $pathway_tuple (@pathway_list) {
         my @tuple = split(/:/,$pathway_tuple); #cut at character :
         my $db_name = $tuple[0];
@@ -985,9 +983,9 @@ sub parse_interpro_tsv {
 #Sorting mixed strings => Sorting alphabetically first, then numerically
 # how to use: my @y = sort by_number @x;
 sub alphaNum {
-    my ( $alet , $anum ) = $a =~ /([^\d]+)(\d+)/;
-    my ( $blet , $bnum ) = $b =~ /([^\d]+)(\d+)/;
-    ( $alet || "a" ) cmp ( $blet || "a" ) or ( $anum || 0 ) <=> ( $bnum || 0 )
+  my ( $alet , $anum ) = $a =~ /([^\d]+)(\d+)/;
+  my ( $blet , $bnum ) = $b =~ /([^\d]+)(\d+)/;
+  ( $alet || "a" ) cmp ( $blet || "a" ) or ( $anum || 0 ) <=> ( $bnum || 0 )
 }
 
 __END__
@@ -1114,7 +1112,7 @@ This option is used to define the number that will be used to begin the numberin
 
 =item B<-o> or B<--output>
 
-String - Output GFF file.  If no output file is specified, the output will be
+String - Output GFF file. If no output file is specified, the output will be
 written to STDOUT.
 
 =item B<-v>

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -962,7 +962,10 @@ sub parse_blast {
     else {
       $l2_gn_present_hash{$l2_key} = "no"; # JN: gn_present=no
     }
-  } # JN: End traverse HoH
+  }
+  print Dumper(\%l2_gn_present_hash);warn "\n l2_gn_present_hash should have yes or no, and long maker... labels (hit return to continue)\n" and getc();
+
+  # JN: End traverse HoH
 
   ####################################################
   ####### Step 3 : Manage NAME final gene name ####### several isoforms could have different gene name reported. So we have to keep that information in some way to report only one STRING to gene name attribute of the gene feature.

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -499,8 +499,7 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
                   #save the new l3 into the new l2 id name
                   $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($newID_level2)} = delete $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)} # delete command return the value before deleting it, so we just transfer the value
                 }
-                #if ($opt_name and mary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) { # JN: Risky test. Need to keep track of operator precedence.
-                if ( ($opt_name and mary_tag_level3 =~ /cds/) or ($primary_tag_level3 =~ /utr/) ) {
+                if ( $opt_name and ($primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) {
                   my $letter_tag = get_letter_tag($primary_tag_level3);
                   $numbering{$letter_tag}++;
                 } # with this option we increment UTR name only for each UTR (cds also)

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -306,7 +306,8 @@ if ($opt_BlastFile || $opt_InterproFile ) {
 
       #Manage Name if option setting
       if ( $opt_BlastFile ) {
-        print Dumper(\%geneNameBlast);warn "\n First check of id_level:$id_level1 in hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
+        #print Dumper(\%geneNameBlast);warn "\n First check of id_level:$id_level1 in hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
+        # JN: example: 'maker-bi03_p1mp_000079f-est_gff_stringtie-gene-3.1' => 'tmem259_3'
 
         if (exists ($geneNameBlast{$id_level1})) { # JN: Does the Name exists in the geneNameBlast hash? If not, no name is stored!
           create_or_replace_tag($feature_level1, 'Name', $geneNameBlast{$id_level1});
@@ -338,7 +339,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           } # End DEBUG
         }
       }
-      print Dumper(\%geneNameBlast);warn "\n hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
+
       #################
       # == LEVEL 2 == #
       #################
@@ -360,11 +361,11 @@ if ($opt_BlastFile || $opt_InterproFile ) {
                 my $mRNABlastName = $mRNANameBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'Name', $mRNABlastName);
               }
-              else {
-                if ($DEBUG) {# JN: Start DEBUG
+              else { # JN: Start DEBUG
+                if ($DEBUG) {
                   create_or_replace_tag($feature_level2, 'Name', 'DEBUG_noname_level2'); # JN: Debug output
-                } # End DEBUG
-              }
+                }
+              } # JN: End DEBUG
 
               my $productData = printProductFunct($level2_ID);
 
@@ -416,6 +417,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       }
     }
   }
+  print Dumper(\%geneNameBlast);warn "\n hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
 }
 
 ###########################
@@ -814,7 +816,7 @@ sub parse_blast {
           }
           else { # JN: Begin DEBUG
             if ($DEBUG) {
-              #### JN: LOOK HERE ####
+              #### JN: 
             }
           } # JN: End DEBUG
           if ($header =~ /PE=([1-5])\s/) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -380,11 +380,11 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       }
     }
   }
+  # JN: Begin DEBUG
+  if ($DEBUG) {
+    print Dumper($missing_name_counter);warn "\n missing_name_counter (hit return to continue)\n" and getc();
+  } # JN: End DEBUG
 }
-# JN: Begin DEBUG
-if ($DEBUG) {
-  print Dumper($missing_name_counter);warn "\n missing_name_counter (hit return to continue)\n" and getc();
-} # JN: End DEBUG
 
 ###########################
 # change names if asked for

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -88,23 +88,6 @@ or pod2usage( {
   -verbose => 1,
   -exitval => 1
 });
-#if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
-#                  'b|blast=s' => \$opt_BlastFile,
-#                  'd|db=s' => \$opt_dataBase,
-#                  'be|blast_evalue=i' => \$opt_blastEvalue,
-#                  'pe=i' => \$opt_pe,
-#                  'i|interpro=s' => \$opt_InterproFile,
-#                  'id=s' => \$opt_name,
-#                  'idau=s' => \$opt_nameU,
-#                  'nb=i' => \$nbIDstart,
-#                  'o|output=s'  => \$opt_output,
-#                  'v' => \$opt_verbose,
-#                  'h|help!' => \$opt_help ) )
-#{
-#  pod2usage( { -message => 'Failed to parse command line',
-#               -verbose => 1,
-#               -exitval => 1 } );
-#}
 
 # Print Help and exit
 if ($opt_help) {
@@ -200,8 +183,6 @@ $ostreamReport->print($stringPrint);
 if ($opt_output) {
   print_time("$stringPrint");
 } # When ostreamReport is a file we have to also display on screen
-
-
 
                   #          +------------------------------------------------------+
                   #          |+----------------------------------------------------+|
@@ -1120,7 +1101,7 @@ will not be reported.
 
 =head1 SYNOPSIS
 
-    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][--db uniprot.fasta][-i interpro_infile.tsv][--id ABCDEF][--output outfile]
+    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][-d uniprot.fasta][-i interpro_infile.tsv][-id ABCDEF][-o outfile.gff]
     agat_sp_manage_functional_annotation.pl --help
 
 =head1 OPTIONS

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -222,11 +222,8 @@ if (defined $opt_BlastFile) {
   foreach my $id (@ids) {
     $allIDs{lc($id)} = $id;
   }
+  # JN: example in %allIDs: 'sp|a0le17|rbfa_magmm' => 'sp|A0LE17|RBFA_MAGMM'
   print_time("Parsing Finished\n\n");
-  if ($DEBUG) { # JN: begin debug
-      print Dumper(\%allIDs);
-      warn "\n allIDs hash (hit return to continue)\n" and getc();
-  } # JN: end debug
   #print "id.".$id"\t";
 
   # parse blast output
@@ -262,6 +259,12 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
   #################
   # == LEVEL 1 == #
   #################
+
+    if ($DEBUG) { # JN: Start DEBUG
+        print Dumper(%{$hash_omniscient->{'level1'}});warn "\n Level 1 (hit return to continue)\n" and getc();
+    } # JN: End DEBUG
+
+
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
     foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
 
@@ -587,7 +590,7 @@ $ostreamReport->print("$stringPrint");
 # PRINT IN FILES
 ####################
 print_time("Writing result...");
-print_omniscient($hash_omniscient, $ostreamGFF);
+print_omniscient($hash_omniscient, $ostreamGFF); # JN: check content of $hash_omniscient
 
       #########################
       ######### END ###########
@@ -1101,7 +1104,7 @@ will not be reported.
 
 =head1 SYNOPSIS
 
-    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][-d uniprot.fasta][-i interpro_infile.tsv][-id ABCDEF][-o outfile.gff]
+    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][-d uniprot.fasta][-i interpro_infile.tsv][-id ABCDEF][-o output]
     agat_sp_manage_functional_annotation.pl --help
 
 =head1 OPTIONS
@@ -1157,7 +1160,7 @@ This option is used to define the number that will be used to begin the numberin
 
 =item B<-o> or B<--output>
 
-String - Output GFF file. If no output file is specified, the output will be
+String - Output folder name with summary files. If no output file is specified, the output will be
 written to STDOUT.
 
 =item B<-v>

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -364,7 +364,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
               # JN: Add info on existence of GN= tag in fasta header in blast db file: gn_present=yes|no|NA
               if (exists($l2_gn_present_hash{$level2_ID})) { # JN: level2_ID: 'maker-bi03_p1mp_001088f-est_gff_stringtie-gene-0.2-mrna-1'
                 my $gn_status = $l2_gn_present_hash{$level2_ID};
-                print Dumper($gn_status);warn "\n gn_status for level2_ID: $level2_ID (hit return to continue)\n" and getc();
                 if ($gn_status eq 'no' ) {
                   $nbGnNotPresentForMrna++;
                 }

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -130,7 +130,8 @@ if ( ! (defined($opt_reffile)) ) {
 #################################################
 
 if ($opt_pe>5 or $opt_pe<1) {
-  print "Error the Protein Existence (PE) value must be between 1 and 5\n";exit;
+  print "Error the Protein Existence (PE) value must be between 1 and 5\n";
+  exit;
 }
 
 my $streamBlast = IO::File->new();
@@ -154,7 +155,7 @@ if (defined $opt_InterproFile) {
 my $ostreamReport;
 my $ostreamGFF;
 my $ostreamLog;
-if (defined($opt_output) ) {
+if (defined($opt_output)) {
   if (-f $opt_output) {
     print "Cannot create a directory with the name $opt_output because a file with this name already exists.\n";exit();
   }
@@ -163,14 +164,14 @@ if (defined($opt_output) ) {
   }
   mkdir $opt_output;
 
-  $ostreamReport = IO::File->new(">".$opt_output."/report.txt" ) or
+  $ostreamReport = IO::File->new(">".$opt_output."/report.txt") or
   croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/report.txt", $! ));
 
   my $file_out_name = fileparse($opt_reffile);
   $ostreamGFF = Bio::Tools::GFF->new(-file => ">$opt_output/$file_out_name", -gff_version => 3 ) or
   croak(sprintf( "Can not open '%s' for writing %s", $opt_output."/".$opt_reffile, $! ));
 
-  $ostreamLog = IO::File->new(">".$opt_output."/error.txt" ) or
+  $ostreamLog = IO::File->new(">".$opt_output."/error.txt") or
   croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/log.txt", $! ));
 }
 else {
@@ -273,7 +274,7 @@ if (defined $opt_InterproFile) {
 
 ###########################
 # change FUNCTIONAL information if asked for
-if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFile) {
+if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproFile) {
   print_time( "load FUNCTIONAL information\n" );
 
   #################
@@ -394,7 +395,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFi
 
 ###########################
 # change names if asked for
-if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
+if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
   print_time("load new IDs");
 
   my %hash_sortBySeq;
@@ -446,7 +447,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
               my $newID_level2 = undef;
 
               #keep track of Maker ID
-              if ($opt_InterproFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+              if ($opt_InterproFile) { #In that case the name given by Maker is removed from ID and from Name. We have to kee a track
                 create_or_replace_tag($feature_level2, 'makerName', $level2_ID);
               }
 
@@ -472,7 +473,7 @@ if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
 
                       #keep track of Maker ID
                       my $level3_ID = $feature_level3->_tag_value('ID');
-                      if ($opt_InterproFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+                      if ($opt_InterproFile) { #In that case the name given by Maker is removed from ID and from Name. We have to kee a track
                         create_or_replace_tag($feature_level3, 'makerName', $level3_ID);
                       }
 
@@ -543,10 +544,10 @@ if ($opt_output) {
 
 
 # NOW summerize
-$stringPrint =""; # reinitialise (use at the beginning)
+$stringPrint = ""; # reinitialise (use at the beginning)
 if ($opt_InterproFile) {
   #print INFO
-  my $lineB=       "_________________________________________________________________________________________________________________________________";
+  my $lineB =      "_________________________________________________________________________________________________________________________________";
   $stringPrint .= " ".$lineB."\n";
   $stringPrint .= "|                         | Nb Total term           | Nb mRNA with term       | Nb mRNA updated by term | Nb gene updated by term |\n";
   $stringPrint .= "|                         | in raw File             |   in raw File           | in our annotation file  | in our annotation file  |\n";
@@ -583,7 +584,7 @@ if ($opt_BlastFile) {
 
   #Lets keep track the duplicated names
   if ($opt_output) {
-    my $duplicatedNameOut = IO::File->new(">".$opt_output."/duplicatedNameFromBlast.txt" );
+    my $duplicatedNameOut = IO::File->new(">".$opt_output."/duplicatedNameFromBlast.txt");
     foreach my $name (sort { $duplicateNameGiven{$b} <=> $duplicateNameGiven{$a} } keys %duplicateNameGiven) {
       print $duplicatedNameOut "$name\t".($duplicateNameGiven{$name}+1)."\n";
     }
@@ -592,7 +593,7 @@ if ($opt_BlastFile) {
 
 if ($opt_name or $opt_nameU) {
   $stringPrint .= "\nList of Letter use to create the uniq ID:\n";
-  foreach my $tag ( keys %tag_hash) {
+  foreach my $tag (keys %tag_hash) {
     $stringPrint .= "$tag => $tag_hash{$tag}\n";
   }
   $stringPrint .= "\n";
@@ -761,7 +762,7 @@ sub parse_blast {
 
   my %candidates;
 
-  while( my $line = <$file_in>) {
+  while(my $line = <$file_in>) {
     my @values = split(/\t/, $line);
     my $l2_name = lc($values[0]);
     my $prot_name = $values[1];
@@ -833,7 +834,7 @@ sub parse_blast {
 
   foreach my $l2 (keys %candidates) {
     if ( $candidates{$l2}[0] eq "error" ) {
-      $ostreamLog->print( "error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output);
+      $ostreamLog->print("error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output);
       next;
     }
 
@@ -870,7 +871,7 @@ sub parse_blast {
           my $geneID = $hash_mRNAGeneLink->{$l2};
           #print "push $geneID $nameGene\n";
           push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
-          push( @{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
+          push(@{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
         }
         else {
           $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if ($opt_verbose or $opt_output);
@@ -954,7 +955,7 @@ sub stringCatcher {
 # method to parse Interpro file
 sub parse_interpro_tsv {
   my($file_in,$fileName) = @_;
-  print( "Reading features from $fileName...\n");
+  print("Reading features from $fileName...\n");
 
   while( my $line = <$file_in>) {
 
@@ -968,9 +969,9 @@ sub parse_interpro_tsv {
     my $db_tuple = $db_name.":".$db_value;
     print "Specific dB: ".$db_tuple."\n" if ($opt_verbose);
 
-    if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
+    if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} )) { #to avoid duplicate
       $TotalTerm{$db_name}++;
-      push ( @{$functionData{$db_name}{$mRNAID}} , $db_tuple );
+      push ( @{$functionData{$db_name}{$mRNAID}}, $db_tuple );
       if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
         $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
         $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
@@ -985,9 +986,9 @@ sub parse_interpro_tsv {
       my $interpro_tuple = "InterPro:".$interpro_value;
       print "interpro dB: ".$interpro_tuple."\n" if ($opt_verbose);
 
-      if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
+      if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} )) { #to avoid duplicate
         $TotalTerm{$db_name}++;
-        push ( @{$functionData{$db_name}{$mRNAID}} , $interpro_tuple );
+        push ( @{$functionData{$db_name}{$mRNAID}}, $interpro_tuple );
         if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
           $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
           $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
@@ -1004,9 +1005,9 @@ sub parse_interpro_tsv {
       foreach my $go_tuple (@go_list) {
         print "GO term: ".$go_tuple."\n" if ($opt_verbose);
 
-        if (! grep( /^\Q$go_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
+        if (! grep( /^\Q$go_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} )) { #to avoid duplicate
           $TotalTerm{$db_name}++;
-          push ( @{$functionData{$db_name}{$mRNAID}} , $go_tuple );
+          push ( @{$functionData{$db_name}{$mRNAID}}, $go_tuple );
           if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
             $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
             $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -129,7 +129,7 @@ if ( ! (defined($opt_reffile)) ) {
 ####### START Manage files (input output) #######
 #################################################
 
-if ($opt_pe>5 or $opt_pe<1) {
+if ( ($opt_pe > 5) or ($opt_pe < 1) ) {
   print "Error the Protein Existence (PE) value must be between 1 and 5\n";
   exit;
 }
@@ -140,7 +140,8 @@ my $streamInter = IO::File->new();
 # Manage Blast File
 if (defined $opt_BlastFile) {
   if (! $opt_dataBase) {
-    print "To use the blast output we also need the fasta of the database used for the blast (--db)\n";exit;
+    print "To use the blast output we also need the fasta of the database used for the blast (--db)\n";
+    exit;
   }
   $streamBlast->open( $opt_BlastFile, 'r' ) or croak( sprintf( "Can not open '%s' for reading: %s", $opt_BlastFile, $! ) );
 }
@@ -157,22 +158,24 @@ my $ostreamGFF;
 my $ostreamLog;
 if (defined($opt_output)) {
   if (-f $opt_output) {
-    print "Cannot create a directory with the name $opt_output because a file with this name already exists.\n";exit();
+    print "Cannot create a directory with the name $opt_output because a file with this name already exists.\n";
+    exit();
   }
   if (-d $opt_output) {
-    print "The output directory choosen already exists. Please geve me another Name.\n";exit();
+    print "The output directory choosen already exists. Please geve me another Name.\n";
+    exit();
   }
   mkdir $opt_output;
 
   $ostreamReport = IO::File->new(">".$opt_output."/report.txt") or
-  croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/report.txt", $! ));
+    croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/report.txt", $! ));
 
   my $file_out_name = fileparse($opt_reffile);
   $ostreamGFF = Bio::Tools::GFF->new(-file => ">$opt_output/$file_out_name", -gff_version => 3 ) or
-  croak(sprintf( "Can not open '%s' for writing %s", $opt_output."/".$opt_reffile, $! ));
+    croak(sprintf( "Can not open '%s' for writing %s", $opt_output."/".$opt_reffile, $! ));
 
   $ostreamLog = IO::File->new(">".$opt_output."/error.txt") or
-  croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/log.txt", $! ));
+    croak( sprintf( "Can not open '%s' for writing %s", $opt_output."/log.txt", $! ));
 }
 else {
   $ostreamReport = \*STDOUT or die ( sprintf( "Can not open '%s' for writing %s", "STDOUT", $! ));
@@ -195,8 +198,6 @@ if ($opt_nameU) {
   $stringPrint .= "->IDs will be changed using <$opt_nameU> as prefix. Features that shared an ID collectively (e.g. CDS, UTRs, etc...) will now have each an uniq ID.\n";
   $prefixName = $opt_nameU;
 }
-
-
 
 # Display
 $ostreamReport->print($stringPrint);
@@ -240,11 +241,15 @@ if (defined $opt_BlastFile) {
   print ("look at the fasta database\n");
   $db = Bio::DB::Fasta->new($opt_dataBase);
   # save ID in lower case to avoid cast problems
-  my @ids = $db->get_all_primary_ids;
+  my @ids = $db->get_all_primary_ids; # JN: here we parse the fasta file
   foreach my $id (@ids) {
     $allIDs{lc($id)} = $id;
   }
   print_time("Parsing Finished\n\n");
+  if ($DEBUG) { # JN: begin debug
+      print Dumper(\%allIDs);
+      warn "\n allIDs hash (hit return to continue)\n" and getc();
+  } # JN: end debug
   #print "id.".$id"\t";
 
   # parse blast output
@@ -262,9 +267,9 @@ if (defined $opt_InterproFile) {
     foreach my $type (keys %functionData) {
       my $ostreamFunct = IO::File->new();
       $ostreamFunct->open( $opt_output."/$type.txt", 'w' ) or
-          croak(
-            sprintf( "Can not open '%s' for writing %s", $opt_output."/$type.txt", $! )
-          );
+        croak(
+          sprintf( "Can not open '%s' for writing %s", $opt_output."/$type.txt", $! )
+        );
       $functionStreamOutput{$type} = $ostreamFunct;
     }
   }
@@ -291,7 +296,7 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
         $feature_level1->remove_tag('Name');
       }
 
-      #Manage Name if otpion setting
+      #Manage Name if option setting
       if ( $opt_BlastFile ) {
         if (exists ($geneNameBlast{$id_level1})) {
           create_or_replace_tag($feature_level1, 'Name', $geneNameBlast{$id_level1});
@@ -373,7 +378,8 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
               my $parentID = $feature_level2->_tag_value('Parent');
 
               if (addFunctions($feature_level2, $opt_output)) {
-                $nbmRNAwithFunction++;$geneWithFunction{$parentID}++;
+                $nbmRNAwithFunction++;
+                $geneWithFunction{$parentID}++;
                 if (exists ($geneWithoutFunction{$parentID})) {
                   delete $geneWithoutFunction{$parentID};
                 }
@@ -421,7 +427,7 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
         #print_time( "Next gene $id_level1\n");
 
         #keep track of Maker ID
-        if ($opt_BlastFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+        if ($opt_BlastFile) { #In that case the name given by Maker is removed from ID and from Name. We have to keep track
           create_or_replace_tag($feature_level1, 'makerName', $level1_ID);
         }
 
@@ -431,10 +437,11 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
           $numbering{$letter_tag} = $nbIDstart;
         }
         $newID_level1 = manageID($prefixName, $numbering{$letter_tag}, $letter_tag );
-        $numbering{$letter_tag }++;
+        $numbering{$letter_tag}++;
         create_or_replace_tag($feature_level1, 'ID', $newID_level1);
 
         $finalID{$feature_level1->_tag_value('ID')} = $newID_level1;
+
         #################
         # == LEVEL 2 == #
         #################
@@ -447,7 +454,7 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
               my $newID_level2 = undef;
 
               #keep track of Maker ID
-              if ($opt_InterproFile) { #In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+              if ($opt_InterproFile) { #In that case the name given by Maker is removed from ID and from Name. We have to keep track
                 create_or_replace_tag($feature_level2, 'makerName', $level2_ID);
               }
 
@@ -461,10 +468,10 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
               create_or_replace_tag($feature_level2, 'Parent', $newID_level1);
 
               $finalID{$level2_ID} = $newID_level2;
+
               #################
               # == LEVEL 3 == #
               #################
-
               foreach my $primary_tag_level3 (keys %{$hash_omniscient->{'level3'}}) { # primary_tag_key_level3 = cds or exon or start_codon or utr etc...
                 if ( exists_keys ($hash_omniscient, ('level3', $primary_tag_level3, lc($level2_ID)) ) ) {
                   foreach my $feature_level3 ( @{$hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)}}) {
@@ -494,22 +501,23 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
                     $finalID{$level3_ID} = $newID_level3;
                   }
                   #save the new l3 into the new l2 id name
-                  $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($newID_level2)} = delete $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)} # delete command return the value before deteling it, so we just transfert the value
+                  $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($newID_level2)} = delete $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)} # delete command return the value before deleting it, so we just transfer the value
                 }
-                if ($opt_name and mary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) { # JN: Risky test. Need to keep track of operator precedence.
+                #if ($opt_name and mary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) { # JN: Risky test. Need to keep track of operator precedence.
+                if ( ($opt_name and mary_tag_level3 =~ /cds/) or ($primary_tag_level3 =~ /utr/) ) {
                   my $letter_tag = get_letter_tag($primary_tag_level3);
                   $numbering{$letter_tag}++;
                 } # with this option we increment UTR name only for each UTR (cds also)
               }
             }
             if ($newID_level1) {
-              $hash_omniscient->{'level2'}{$primary_tag_level2}{lc($newID_level1)} = delete $hash_omniscient->{'level2'}{$primary_tag_level2}{$id_level1}; # modify the id key of the hash. The delete command return the value before deteling it, so we just transfert the value
+              $hash_omniscient->{'level2'}{$primary_tag_level2}{lc($newID_level1)} = delete $hash_omniscient->{'level2'}{$primary_tag_level2}{$id_level1}; # modify the id key of the hash. The delete command return the value before deleting it, so we just transfer the value
             }
           }
         }
 
         if ($newID_level1) {
-          $hash_omniscient->{'level1'}{$primary_tag_level1}{lc($newID_level1)} = delete $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1}; # modify the id key of the hash. The delete command return the value before deteling it, so we just transfert the value
+          $hash_omniscient->{'level1'}{$primary_tag_level1}{lc($newID_level1)} = delete $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1}; # modify the id key of the hash. The delete command return the value before deleting it, so we just transfer the value
         }
       }
     }
@@ -540,7 +548,7 @@ if ($opt_output) {
 }
 
 
-# NOW summerize
+# NOW summarize
 $stringPrint = ""; # reinitialise (use at the beginning)
 if ($opt_InterproFile) {
   #print INFO
@@ -574,7 +582,7 @@ if ($opt_InterproFile) {
 
 if ($opt_BlastFile) {
   my $nbGeneDuplicated = keys %duplicateNameGiven;
-  $nbDuplicateNameGiven = $nbDuplicateNameGiven+$nbGeneDuplicated; # Until now we have counted only name in more, now we add the original name.
+  $nbDuplicateNameGiven = $nbDuplicateNameGiven + $nbGeneDuplicated; # Until now we have counted only name in more, now we add the original name.
   $stringPrint .= "$nbGeneNameInBlast gene names have been retrieved in the blast file. $nbNamedGene gene names have been successfully inferred.\n".
   "Among them there are $nbGeneDuplicated names that are shared at least per two genes for a total of $nbDuplicateNameGiven genes.\n";
   # "We have $nbDuplicateName gene names duplicated ($nbDuplicateNameGiven - $nbGeneDuplicated).";
@@ -583,7 +591,7 @@ if ($opt_BlastFile) {
   if ($opt_output) {
     my $duplicatedNameOut = IO::File->new(">".$opt_output."/duplicatedNameFromBlast.txt");
     foreach my $name (sort { $duplicateNameGiven{$b} <=> $duplicateNameGiven{$a} } keys %duplicateNameGiven) {
-      print $duplicatedNameOut "$name\t".($duplicateNameGiven{$name}+1)."\n";
+      print $duplicatedNameOut "$name\t".($duplicateNameGiven{$name} + 1)."\n";
     }
   }
 }
@@ -621,7 +629,7 @@ print_omniscient($hash_omniscient, $ostreamGFF);
                  ##
 
 
-#create or take the uniq letter TAG
+#create or take the unique letter TAG
 sub get_letter_tag {
   my ($tag) = @_;
 
@@ -771,7 +779,7 @@ sub parse_blast {
     print "Evalue: ".$evalue."\n" if ($opt_verbose);
 
     #if does not exist fill it if over the minimum evalue
-    if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}}> 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
+    if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}} > 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
         my $protID_correct = undef;
 
@@ -779,7 +787,7 @@ sub parse_blast {
           $protID_correct = $allIDs{lc($prot_name)};
           my $header = $db->header( $protID_correct );
           if (! $header =~ m/GN=/) {
-              # JN: No gene name. Should increment a counter here, and/or set gn_missing=yes?
+            # JN: No gene name. Should increment a counter here, and/or set gn_missing=yes?
             $ostreamLog->print( "No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
             $candidates{$l2_name} = ["error", $evalue, $prot_name."-".$l2_name];
           }
@@ -917,7 +925,7 @@ sub parse_blast {
         $mRNANameBlast{$mRNAList[0]} = $String;
       }
     }
-    else { #in case where name was already used, we will modified it by addind a number like "_2"
+    else { #in case where name was already used, we will modify it by adding a number like "_2"
       $nbDuplicateName++;
       $geneNewNameUsed{$String}++;
       my $nbFound = $geneNewNameUsed{$String};
@@ -939,13 +947,13 @@ sub parse_blast {
   }
 }
 
-#uniprotHeader string spliter
+#uniprotHeader string splitter
 sub stringCatcher {
   my($String) = @_;
   my $newString = undef;
 
   if ( $String =~ m/(\w{2}=.+?(?= \w{2}=))(.+)/ ) {
-    $newString = substr $String, length($1)+1;
+    $newString = substr $String, length($1) + 1;
     return ($newString, $1);
   }
   else {
@@ -980,7 +988,7 @@ sub parse_interpro_tsv {
     }
 
     #check for interpro
-    if ( $sizeList>11 ) {
+    if ( $sizeList > 11 ) {
       my $db_name = "InterPro";
       my $interpro_value = $values[11];
       $interpro_value =~ s/\n//g;
@@ -998,7 +1006,7 @@ sub parse_interpro_tsv {
     }
 
     #check for GO
-    if ( $sizeList>13 ) {
+    if ( $sizeList > 13 ) {
       my $db_name = "GO";
       my $go_flat_list = $values[13];
       $go_flat_list =~ s/\n//g;
@@ -1018,7 +1026,7 @@ sub parse_interpro_tsv {
     }
 
     #check for pathway
-    if ( $sizeList>14 ) {
+    if ( $sizeList > 14 ) {
       my $pathway_flat_list = $values[14];
       $pathway_flat_list =~ s/\n//g;
       $pathway_flat_list =~ s/ //g;

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -271,6 +271,10 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
       my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
       #print $feature_level1."\n";
+      if ($DEBUG) { # JN: Start DEBUG
+        print Dumper($feature_level1);warn "\n feature_level1 (hit return to continue)\n" and getc();
+      } # JN: End DEBUG
+
       # Clean NAME attribute
       if ($feature_level1->has_tag('Name')) {
         $feature_level1->remove_tag('Name');
@@ -302,6 +306,12 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
             $geneNameGiven{$nameToCompare}++;
           } # first time we have given this name
         }
+        else {
+          if ($DEBUG) { # JN: Start DEBUG
+            print Dumper();warn "\n id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
+          } # JN: End DEBUG
+        }
+
       }
 
       #################

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -45,7 +45,7 @@ my %mRNAUniprotIDFromBlast;
 my %mRNAproduct;
 my %geneNameGiven;
 my %duplicateNameGiven;
-my %fasta_id_gn_hash = ();     # JN: key: 'sp|a6w1c3|hem1_marms' , value: 'hema' or undef
+my %fasta_id_gn_hash = ();     # JN: key: 'sp|a6w1c3|hem1_marms' , value: 'hema' etc or undef
 my %l2_gn_present_hash = ();   # JN: Key: 'maker-bi03_p1mp_001088f-est_gff_stringtie-gene-0.2-mrna-1', value: 'yes' or 'no'
 my $nbGnNotPresentInDb = 0;    # JN: Count entries without GN in db
 my $nbGnNotPresentForMrna = 0; # JN: Count mRNAs without GN in db

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -34,6 +34,7 @@ my $nbIDstart = 1;
 my $prefixName = undef;
 my %tag_hash;
 my @tag_list;
+my %l2_gn_missing_hash = (); # JN: Key: level2, value: gn_missing=yes|no|NA
 # END PARAMETERS - OPTION
 
 # FOR FUNCTIONS BLAST#
@@ -967,7 +968,7 @@ sub parse_blast {
   # JN: Begin gn_missing
   # JN: Go through HoH and see if there are any level2 entries with any "DEBUG_missing_GN_in_db",
   # JN: and if so, is "DEBUG_missing_GN_in_db" the only value?
-  my %l2_gn_missing_hash = (); # JN: Key: level2, value: gn_missing=yes
+  #my %l2_gn_missing_hash = (); # JN: Key: level2, value: gn_missing=yes
   while ( my ($l2, $values) = each %HoH ) {
     my $size = scalar(%{$values});
     if ($size == 1) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -295,6 +295,8 @@ if ($opt_BlastFile || $opt_InterproFile ) {
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
     foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
 
+      print Dumper($id_level1);warn "\n id_level1 (hit return to continue)\n" and getc(); # JN: tmp debug print
+
       my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
       # Clean NAME attribute
@@ -334,7 +336,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           } # first time we have given this name
         }
         else { # JN: Start DEBUG
-          if ($DEBUG) {
+          if ($DEBUG > 1) {
             create_or_replace_tag($feature_level1, 'Name', 'DEBUG_noname_in_blast_level1'); # JN: Debug output
           } # End DEBUG
         }

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -91,7 +91,7 @@ if ($opt_help) {
                  -message => "$header\n" } );
 }
 
-if ( ! (defined($opt_reffile)) ){
+if ( ! (defined($opt_reffile)) ) {
     pod2usage( {
            -message => "$header\nAt least 1 parameter is mandatory:\nInput reference gff file (--f)\n\n".
            "Many optional parameters are available. Look at the help documentation to know more.\n",
@@ -103,7 +103,7 @@ if ( ! (defined($opt_reffile)) ){
 ####### START Manage files (input output) #######
 #################################################
 
-if($opt_pe>5 or $opt_pe<1){
+if ($opt_pe>5 or $opt_pe<1) {
   print "Error the Protein Existence (PE) value must be between 1 and 5\n";exit;
 }
 
@@ -111,15 +111,15 @@ my $streamBlast = IO::File->new();
 my $streamInter = IO::File->new();
 
 # Manage Blast File
-if (defined $opt_BlastFile){
-  if (! $opt_dataBase){
+if (defined $opt_BlastFile) {
+  if (! $opt_dataBase) {
     print "To use the blast output we also need the fasta of the database used for the blast (--db)\n";exit;
   }
   $streamBlast->open( $opt_BlastFile, 'r' ) or croak( sprintf( "Can not open '%s' for reading: %s", $opt_BlastFile, $! ) );
 }
 
 # Manage Interpro file
-if (defined $opt_InterproFile){
+if (defined $opt_InterproFile) {
   $streamInter->open( $opt_InterproFile, 'r' ) or croak( sprintf( "Can not open '%s' for reading: %s", $opt_InterproFile, $! ) );
 }
 
@@ -129,10 +129,10 @@ my $ostreamReport;
 my $ostreamGFF;
 my $ostreamLog;
 if (defined($opt_output) ) {
-  if (-f $opt_output){
+  if (-f $opt_output) {
       print "Cannot create a directory with the name $opt_output because a file with this name already exists.\n";exit();
   }
-  if (-d $opt_output){
+  if (-d $opt_output) {
       print "The output directory choosen already exists. Please geve me another Name.\n";exit();
   }
   mkdir $opt_output;
@@ -159,12 +159,12 @@ else {
 #my $stringPrint = strftime "%m/%d/%Y at %Hh%Mm%Ss", localtime;
 my $stringPrint = strftime "%m/%d/%Y", localtime;
 $stringPrint .= "\nusage: $0 @copyARGV\n";
-if ($opt_name){
+if ($opt_name) {
   $prefixName=$opt_name;
   $stringPrint .= "->IDs are changed using <$opt_name> as prefix.\nIn the case of discontinuous features (i.e. a single feature that exists over multiple genomic locations) the same ID may appear on multiple lines.".
   " All lines that share an ID collectively represent a signle feature.\n";
 }
-if ($opt_nameU){
+if ($opt_nameU) {
   $stringPrint .= "->IDs will be changed using <$opt_nameU> as prefix. Features that shared an ID collectively (e.g. CDS, UTRs, etc...) will now have each an uniq ID.\n";
   $prefixName=$opt_nameU;
 }
@@ -173,7 +173,7 @@ if ($opt_nameU){
 
 # Display
 $ostreamReport->print($stringPrint);
-if($opt_output){ print_time("$stringPrint");} # When ostreamReport is a file we have to also display on screen
+if ($opt_output) { print_time("$stringPrint");} # When ostreamReport is a file we have to also display on screen
 
 
 
@@ -207,13 +207,13 @@ print_omniscient_statistics(
 # Manage Blast File #
 my $db;
 my %allIDs;
-if (defined $opt_BlastFile){
+if (defined $opt_BlastFile) {
   # read fasta file and save info in memory
   print ("look at the fasta database\n");
   $db = Bio::DB::Fasta->new($opt_dataBase);
   # save ID in lower case to avoid cast problems
   my @ids      = $db->get_all_primary_ids;
-  foreach my $id (@ids ){$allIDs{lc($id)}=$id;}
+  foreach my $id (@ids) {$allIDs{lc($id)}=$id;}
   print_time("Parsing Finished\n\n");
   #print "id.".$id"\t";
 
@@ -224,12 +224,12 @@ if (defined $opt_BlastFile){
 
 ########################
 # Manage Interpro File #
-if (defined $opt_InterproFile){
+if (defined $opt_InterproFile) {
   parse_interpro_tsv($streamInter,$opt_InterproFile);
 
   # create streamOutput
-  if($opt_output){
-    foreach my $type (keys %functionData){
+  if ($opt_output) {
+    foreach my $type (keys %functionData) {
       my $ostreamFunct = IO::File->new();
       $ostreamFunct->open( $opt_output."/$type.txt", 'w' ) or
           croak(
@@ -244,26 +244,26 @@ if (defined $opt_InterproFile){
 
 ###########################
 # change FUNCTIONAL information if asked for
-if ($opt_BlastFile || $opt_InterproFile ){#|| $opt_BlastFile || $opt_InterproFile){
+if ($opt_BlastFile || $opt_InterproFile ) {#|| $opt_BlastFile || $opt_InterproFile) {
     print_time( "load FUNCTIONAL information\n" );
 
   #################
   # == LEVEL 1 == #
   #################
-  foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}){ # primary_tag_level1 = gene or repeat etc...
-    foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}){
+  foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
+    foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
 
       my $feature_level1=$hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
   #    print $feature_level1."\n";
       # Clean NAME attribute
-      if($feature_level1->has_tag('Name')){
+      if ($feature_level1->has_tag('Name')) {
         $feature_level1->remove_tag('Name');
       }
 
       #Manage Name if otpion setting
-      if( $opt_BlastFile ){
-        if (exists ($geneNameBlast{$id_level1})){
+      if ( $opt_BlastFile ) {
+        if (exists ($geneNameBlast{$id_level1})) {
           create_or_replace_tag($feature_level1, 'Name', $geneNameBlast{$id_level1});
           $nbNamedGene++;
 
@@ -272,12 +272,12 @@ if ($opt_BlastFile || $opt_InterproFile ){#|| $opt_BlastFile || $opt_InterproFil
           $nameClean =~ s/_([2-9]{1}[0-9]*|[0-9]{2,})*$//;
 
           my $nameToCompare;
-          if(exists ($nameBlast{$nameClean})){ # We check that is really a name where we added the suffix _1
+          if (exists ($nameBlast{$nameClean})) { # We check that is really a name where we added the suffix _1
             $nameToCompare=$nameClean;
           }
           else{$nameToCompare=$geneNameBlast{$id_level1};} # it was already a gene_name like BLABLA_12
 
-          if(exists ($geneNameGiven{$nameToCompare})){
+          if (exists ($geneNameGiven{$nameToCompare})) {
               $nbDuplicateNameGiven++; # track total
               $duplicateNameGiven{$nameToCompare}++; # track diversity
           }
@@ -288,35 +288,35 @@ if ($opt_BlastFile || $opt_InterproFile ){#|| $opt_BlastFile || $opt_InterproFil
       #################
       # == LEVEL 2 == #
       #################
-      foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}){ # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
+      foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}) { # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
 
-        if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_key_level2, $id_level1) ) ){
+        if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_key_level2, $id_level1) ) ) {
           foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_key_level2}{$id_level1}}) {
 
             my $level2_ID = lc($feature_level2->_tag_value('ID'));
             # Clean NAME attribute
-            if($feature_level2->has_tag('Name')){
+            if ($feature_level2->has_tag('Name')) {
               $feature_level2->remove_tag('Name');
             }
 
             #Manage Name if option set
-            if($opt_BlastFile){
+            if ($opt_BlastFile) {
               # add gene Name
-              if (exists ($mRNANameBlast{$level2_ID})){
+              if (exists ($mRNANameBlast{$level2_ID})) {
                 my $mRNABlastName=$mRNANameBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'Name', $mRNABlastName);
               }
               my $productData=printProductFunct($level2_ID);
 
               #add UniprotID attribute
-              if (exists ($mRNAUniprotIDFromBlast{$level2_ID})){
+              if (exists ($mRNAUniprotIDFromBlast{$level2_ID})) {
                 my $mRNAUniprotID=$mRNAUniprotIDFromBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'uniprot_id', $mRNAUniprotID);
               }
 
               #add product attribute
-              if ($productData ne ""){
-                if($feature_level2->has_tag('pseudo')){
+              if ($productData ne "") {
+                if ($feature_level2->has_tag('pseudo')) {
                     create_or_replace_tag($feature_level2, 'Note', "product:$productData");
                 }
                 else{
@@ -324,7 +324,7 @@ if ($opt_BlastFile || $opt_InterproFile ){#|| $opt_BlastFile || $opt_InterproFil
                 }
               }
               else {
-                if($feature_level2->has_tag('pseudo')){
+                if ($feature_level2->has_tag('pseudo')) {
                     create_or_replace_tag($feature_level2, 'Note', "product:hypothetical protein");
                 }
                 else{
@@ -335,18 +335,18 @@ if ($opt_BlastFile || $opt_InterproFile ){#|| $opt_BlastFile || $opt_InterproFil
             }
 
             # print function if option
-            if($opt_InterproFile){
+            if ($opt_InterproFile) {
               my $parentID=$feature_level2->_tag_value('Parent');
 
-              if (addFunctions($feature_level2, $opt_output)){
+              if (addFunctions($feature_level2, $opt_output)) {
                 $nbmRNAwithFunction++;$geneWithFunction{$parentID}++;
-                if(exists ($geneWithoutFunction{$parentID})){
+                if (exists ($geneWithoutFunction{$parentID})) {
                   delete $geneWithoutFunction{$parentID};
                 }
               }
               else{
                 $nbmRNAwithoutFunction++;
-                if(! exists ($geneWithFunction{$parentID})){
+                if (! exists ($geneWithFunction{$parentID})) {
                   $geneWithoutFunction{$parentID}++;
                 }
               }
@@ -361,12 +361,12 @@ if ($opt_BlastFile || $opt_InterproFile ){#|| $opt_BlastFile || $opt_InterproFil
 
 ###########################
 # change names if asked for
-if ($opt_nameU || $opt_name ){#|| $opt_BlastFile || $opt_InterproFile){
+if ($opt_nameU || $opt_name ) {#|| $opt_BlastFile || $opt_InterproFile) {
   print_time("load new IDs");
 
   my %hash_sortBySeq;
-  foreach my $tag_level1 ( keys %{$hash_omniscient->{'level1'}}){
-    foreach my $level1_id ( keys %{$hash_omniscient->{'level1'}{$tag_level1}}){
+  foreach my $tag_level1 ( keys %{$hash_omniscient->{'level1'}}) {
+    foreach my $level1_id ( keys %{$hash_omniscient->{'level1'}{$tag_level1}}) {
       my $position=$hash_omniscient->{'level1'}{$tag_level1}{$level1_id}->seq_id;
       push (@{$hash_sortBySeq{$position}{$tag_level1}}, $hash_omniscient->{'level1'}{$tag_level1}{$level1_id});
     }
@@ -376,24 +376,24 @@ if ($opt_nameU || $opt_name ){#|| $opt_BlastFile || $opt_InterproFile){
   # == LEVEL 1 == #
   #################
   #Read by seqId to sort properly the output by seq ID
-  foreach my $seqid (sort alphaNum keys %hash_sortBySeq){ # loop over all the feature level1
+  foreach my $seqid (sort alphaNum keys %hash_sortBySeq) { # loop over all the feature level1
 
-    foreach my $primary_tag_level1 (sort {$a cmp $b} keys %{$hash_sortBySeq{$seqid}}){
+    foreach my $primary_tag_level1 (sort {$a cmp $b} keys %{$hash_sortBySeq{$seqid}}) {
 
-      foreach my $feature_level1 ( sort {$a->start <=> $b->start} @{$hash_sortBySeq{$seqid}{$primary_tag_level1}}){
+      foreach my $feature_level1 ( sort {$a->start <=> $b->start} @{$hash_sortBySeq{$seqid}{$primary_tag_level1}}) {
         my $level1_ID=$feature_level1->_tag_value('ID');
         my $id_level1 = lc($level1_ID);
         my $newID_level1=undef;
         #print_time( "Next gene $id_level1\n");
 
         #keep track of Maker ID
-        if($opt_BlastFile){#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+        if ($opt_BlastFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
           create_or_replace_tag($feature_level1, 'makerName', $level1_ID);
         }
 
         my $letter_tag = get_letter_tag($primary_tag_level1);
 
-        if(! exists_keys(\%numbering,($letter_tag ))){$numbering{$letter_tag }=$nbIDstart;}
+        if (! exists_keys(\%numbering,($letter_tag ))) {$numbering{$letter_tag }=$nbIDstart;}
         $newID_level1 = manageID($prefixName, $numbering{$letter_tag }, $letter_tag );
         $numbering{$letter_tag }++;
         create_or_replace_tag($feature_level1, 'ID', $newID_level1);
@@ -402,21 +402,21 @@ if ($opt_nameU || $opt_name ){#|| $opt_BlastFile || $opt_InterproFile){
         #################
         # == LEVEL 2 == #
         #################
-        foreach my $primary_tag_level2 (keys %{$hash_omniscient->{'level2'}}){ # primary_tag_level2 = mrna or mirna or ncrna or trna etc...
+        foreach my $primary_tag_level2 (keys %{$hash_omniscient->{'level2'}}) { # primary_tag_level2 = mrna or mirna or ncrna or trna etc...
 
-          if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_level2, $id_level1) ) ){
+          if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_level2, $id_level1) ) ) {
             foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_level2}{$id_level1}}) {
 
               my $level2_ID = $feature_level2->_tag_value('ID');
               my $newID_level2=undef;
 
               #keep track of Maker ID
-              if($opt_InterproFile){#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+              if ($opt_InterproFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
                 create_or_replace_tag($feature_level2, 'makerName', $level2_ID);
               }
 
               my $letter_tag = get_letter_tag($primary_tag_level2);
-              if(! exists_keys(\%numbering,($letter_tag))){$numbering{$letter_tag}=$nbIDstart;}
+              if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag}=$nbIDstart;}
               $newID_level2 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
               $numbering{$letter_tag}++;
               create_or_replace_tag($feature_level2, 'ID', $newID_level2);
@@ -427,23 +427,23 @@ if ($opt_nameU || $opt_name ){#|| $opt_BlastFile || $opt_InterproFile){
               # == LEVEL 3 == #
               #################
 
-              foreach my $primary_tag_level3 (keys %{$hash_omniscient->{'level3'}}){ # primary_tag_key_level3 = cds or exon or start_codon or utr etc...
+              foreach my $primary_tag_level3 (keys %{$hash_omniscient->{'level3'}}) { # primary_tag_key_level3 = cds or exon or start_codon or utr etc...
 
-                  if ( exists_keys ($hash_omniscient,('level3',$primary_tag_level3, lc($level2_ID)) ) ){
+                  if ( exists_keys ($hash_omniscient,('level3',$primary_tag_level3, lc($level2_ID)) ) ) {
 
                     foreach my $feature_level3 ( @{$hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)}}) {
 
                       #keep track of Maker ID
                       my $level3_ID = $feature_level3->_tag_value('ID');
-                      if($opt_InterproFile){#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
+                      if ($opt_InterproFile) {#In that case the name given by Maker is removed from ID and from Name. We have to kee a track
                         create_or_replace_tag($feature_level3, 'makerName', $level3_ID);
                       }
 
                       my $letter_tag = get_letter_tag($primary_tag_level3);
-                      if(! exists_keys(\%numbering,($letter_tag))){$numbering{$letter_tag}=$nbIDstart;}
+                      if (! exists_keys(\%numbering,($letter_tag))) {$numbering{$letter_tag}=$nbIDstart;}
                       my $newID_level3 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
-                      if( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) {
-                        if($opt_nameU){
+                      if ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) {
+                        if ($opt_nameU) {
                           $numbering{$letter_tag}++;
                         }
                       }
@@ -458,20 +458,20 @@ if ($opt_nameU || $opt_name ){#|| $opt_BlastFile || $opt_InterproFile){
                     #save the new l3 into the new l2 id name
                     $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($newID_level2)} = delete $hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)} # delete command return the value before deteling it, so we just transfert the value
                   }
-                  if ($opt_name and  ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ){
+                  if ($opt_name and  ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) ) {
                     my $letter_tag = get_letter_tag($primary_tag_level3);
                     $numbering{$letter_tag}++;
                   } # with this option we increment UTR name only for each UTR (cds also)
 
               }
             }
-            if($newID_level1){
+            if ($newID_level1) {
               $hash_omniscient->{'level2'}{$primary_tag_level2}{lc($newID_level1)} = delete $hash_omniscient->{'level2'}{$primary_tag_level2}{$id_level1}; # modify the id key of the hash. The delete command return the value before deteling it, so we just transfert the value
             }
           }
         }
 
-        if($newID_level1){
+        if ($newID_level1) {
           $hash_omniscient->{'level1'}{$primary_tag_level1}{lc($newID_level1)} = delete $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1}; # modify the id key of the hash. The delete command return the value before deteling it, so we just transfert the value
         }
       }
@@ -487,12 +487,12 @@ if ($opt_nameU || $opt_name ){#|| $opt_BlastFile || $opt_InterproFile){
 # print FUNCTIONAL INFORMATION
 
 # first table name\tfunction
-if($opt_output){
-  foreach my $function_type (keys %functionOutput){
+if ($opt_output) {
+  foreach my $function_type (keys %functionOutput) {
     my $streamOutput=$functionStreamOutput{$function_type};
-    foreach my $ID (keys %{$functionOutput{$function_type}}){
+    foreach my $ID (keys %{$functionOutput{$function_type}}) {
 
-      if ($opt_nameU || $opt_name ){
+      if ($opt_nameU || $opt_name ) {
         print $streamOutput  $finalID{$ID}."\t".$functionOutput{$function_type}{$ID}."\n";
       }
       else{
@@ -505,7 +505,7 @@ if($opt_output){
 
 # NOW summerize
 $stringPrint =""; # reinitialise (use at the beginning)
-if ($opt_InterproFile){
+if ($opt_InterproFile) {
   #print INFO
   my $lineB=       "_________________________________________________________________________________________________________________________________";
   $stringPrint .= " ".$lineB."\n";
@@ -513,7 +513,7 @@ if ($opt_InterproFile){
   $stringPrint .= "|                         | in raw File             |   in raw File           | in our annotation file  | in our annotation file  |\n";
   $stringPrint .= "|".$lineB."|\n";
 
-  foreach my $type (sort keys %functionData){
+  foreach my $type (sort keys %functionData) {
     my $total_type = $TotalTerm{$type};
     my $mRNA_type_raw = $functionDataAdded{$type};
     my $mRNA_type = keys %{$mRNAAssociatedToTerm{$type}};
@@ -523,7 +523,7 @@ if ($opt_InterproFile){
 
   #RESUME TOTAL OF FUNCTION ATTACHED
   my $listOfFunction;
-  foreach my $funct (sort keys %functionData){
+  foreach my $funct (sort keys %functionData) {
     $listOfFunction.="$funct,";
   }
   chop $listOfFunction;
@@ -535,7 +535,7 @@ if ($opt_InterproFile){
                   "nb gene with Functional annotation ($listOfFunction) = $nbGeneWithFunction\n";
 }
 
-if($opt_BlastFile){
+if ($opt_BlastFile) {
   my $nbGeneDuplicated=keys %duplicateNameGiven;
   $nbDuplicateNameGiven=$nbDuplicateNameGiven+$nbGeneDuplicated; # Until now we have counted only name in more, now we add the original name.
   $stringPrint .= "$nbGeneNameInBlast gene names have been retrieved in the blast file. $nbNamedGene gene names have been successfully inferred.\n".
@@ -543,17 +543,17 @@ if($opt_BlastFile){
   # "We have $nbDuplicateName gene names duplicated ($nbDuplicateNameGiven - $nbGeneDuplicated).";
 
   #Lets keep track the duplicated names
-  if($opt_output){
+  if ($opt_output) {
     my $duplicatedNameOut=IO::File->new(">".$opt_output."/duplicatedNameFromBlast.txt" );
-    foreach my $name (sort { $duplicateNameGiven{$b} <=> $duplicateNameGiven{$a} } keys %duplicateNameGiven){
+    foreach my $name (sort { $duplicateNameGiven{$b} <=> $duplicateNameGiven{$a} } keys %duplicateNameGiven) {
       print $duplicatedNameOut "$name\t".($duplicateNameGiven{$name}+1)."\n";
     }
   }
 }
 
-if($opt_name or $opt_nameU){
+if ($opt_name or $opt_nameU) {
   $stringPrint .= "\nList of Letter use to create the uniq ID:\n";
-  foreach my $tag ( keys %tag_hash){
+  foreach my $tag ( keys %tag_hash) {
     $stringPrint .= "$tag => $tag_hash{$tag}\n";
   }
   $stringPrint .= "\n";
@@ -589,7 +589,7 @@ sub get_letter_tag{
   my ($tag)=@_;
 
   $tag = lc($tag);
-  if(! exists_keys (\%tag_hash,( $tag ))) {
+  if (! exists_keys (\%tag_hash,( $tag ))) {
 
     my $substringLength=1;
     my $letter = uc(substr($tag, 0, $substringLength));
@@ -610,7 +610,7 @@ sub get_letter_tag{
 sub manageGeneNameBlast{
 
   my ($geneName)=@_;
-  foreach my $element (keys %$geneName){
+  foreach my $element (keys %$geneName) {
     my @tab=@{$geneName->{$element}};
 
     my %seen;
@@ -626,9 +626,9 @@ sub manageGeneNameBlast{
 
     my $finalName="";
     my $cpt=0;
-    foreach my $name (@unique){  #if several name we will concatenate them together
+    foreach my $name (@unique) {  #if several name we will concatenate them together
 
-        if ($cpt == 0){
+        if ($cpt == 0) {
           $finalName .="$name";
           $cpt++;
         }
@@ -646,7 +646,7 @@ sub manageID{
   my $result="";
   my $numberNum=11;
   my $GoodNum="";
-  for (my $i=0; $i<$numberNum-length($nbName); $i++){
+  for (my $i=0; $i<$numberNum-length($nbName); $i++) {
     $GoodNum.="0";
   }
   $GoodNum.=$nbName;
@@ -660,10 +660,10 @@ sub printProductFunct{
   my ($refname)=@_;
   my $String="";
   my $first="yes";
-  if (exists $mRNAproduct{$refname}){
+  if (exists $mRNAproduct{$refname}) {
     foreach my $element (@{$mRNAproduct{$refname}})
     {
-      if($first eq "yes"){
+      if ($first eq "yes") {
         $String.="$element";
         $first="no";
       }
@@ -678,30 +678,30 @@ sub addFunctions{
 
   my $functionAdded=undef;
   my $ID=lc($feature->_tag_value('ID'));
-  foreach my $function_type (keys %functionData){
+  foreach my $function_type (keys %functionData) {
 
 
-    if(exists ($functionData{$function_type}{$ID})){
+    if (exists ($functionData{$function_type}{$ID})) {
       $functionAdded="true";
 
       my $data_list;
 
-      if(lc($function_type) eq "go"){
-        foreach my $data (@{$functionData{$function_type}{$ID}}){
+      if (lc($function_type) eq "go") {
+        foreach my $data (@{$functionData{$function_type}{$ID}}) {
           $feature->add_tag_value('Ontology_term', $data);
           $data_list.="$data,";
           $functionDataAdded{$function_type}++;
         }
       }
       else{
-        foreach my $data (@{$functionData{$function_type}{$ID}}){
+        foreach my $data (@{$functionData{$function_type}{$ID}}) {
           $feature->add_tag_value('Dbxref', $data);
           $data_list.="$data,";
           $functionDataAdded{$function_type}++;
         }
       }
 
-      if ($opt_output){
+      if ($opt_output) {
           my $ID = $feature->_tag_value('ID');
           chop $data_list;
           $functionOutput{$function_type}{$ID}=$data_list;
@@ -726,57 +726,57 @@ sub parse_blast {
     my $prot_name = $values[1];
     my @prot_name_sliced = split(/\|/, $values[1]);
     my $uniprot_id = $prot_name_sliced[1];
-    print "uniprot_id: ".$uniprot_id."\n" if($opt_verbose);
+    print "uniprot_id: ".$uniprot_id."\n" if ($opt_verbose);
     my $evalue = $values[10];
-    print "Evalue: ".$evalue."\n" if($opt_verbose);
+    print "Evalue: ".$evalue."\n" if ($opt_verbose);
 
     #if does not exist fill it if over the minimum evalue
-    if (! exists_keys(\%candidates,($l2_name)) or @{$candidates{$l2_name}}> 3 ){ # the second one means we saved an error message as candidates we still have to try to find a proper one
-      if( $evalue <= $opt_blastEvalue ) {
+    if (! exists_keys(\%candidates,($l2_name)) or @{$candidates{$l2_name}}> 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
+      if ( $evalue <= $opt_blastEvalue ) {
         my $protID_correct=undef;
 
-        if( exists $allIDs{lc($prot_name)}){
+        if ( exists $allIDs{lc($prot_name)}) {
           $protID_correct = $allIDs{lc($prot_name)};
           my $header = $db->header( $protID_correct );
-          if (! $header =~ m/GN=/){
-            $ostreamLog->print( "No gene name (GN=) in this header $header\n") if($opt_verbose or $opt_output);
+          if (! $header =~ m/GN=/) {
+            $ostreamLog->print( "No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
             $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
           }
-          if($header =~ /PE=([1-5])\s/){
-            if($1 <= $opt_pe){
+          if ($header =~ /PE=([1-5])\s/) {
+            if ($1 <= $opt_pe) {
               $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
             }
           }
-          else{$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if($opt_verbose or $opt_output); }
+          else{$ostreamLog->print("No Protein Existence (PE) information in this header: $header\n")if ($opt_verbose or $opt_output); }
         }
         else{
-          $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if($opt_verbose or $opt_output);
+          $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n" ) if ($opt_verbose or $opt_output);
           $candidates{$l2_name}=["error", $evalue, $prot_name."-".$l2_name];
         }
       }
     }
-    elsif( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
+    elsif ( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
       my $protID_correct=undef;
 
-      if( exists $allIDs{lc($prot_name)}){
+      if ( exists $allIDs{lc($prot_name)}) {
         $protID_correct = $allIDs{lc($prot_name)};
         my $header = $db->header( $protID_correct );
-        if (! $header =~ m/GN=/){
-          $ostreamLog->print("No gene name (GN=) in this header $header\n") if($opt_verbose or $opt_output);
+        if (! $header =~ m/GN=/) {
+          $ostreamLog->print("No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
         }
-        if($header =~ /PE=([1-5])\s/){
-          if($1 <= $opt_pe){
+        if ($header =~ /PE=([1-5])\s/) {
+          if ($1 <= $opt_pe) {
             $candidates{$l2_name}=[$header, $evalue, $uniprot_id];
           }
         }
-        else{ $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if($opt_verbose or $opt_output); }
+        else{ $ostreamLog->print( "No Protein Existence (PE) information in this header: $header\n") if ($opt_verbose or $opt_output); }
       }
-      else{ $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if($opt_verbose or $opt_output);}
+      else{ $ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast. (l2=$l2_name)\n") if ($opt_verbose or $opt_output);}
     }
   }
 
   my $nb_desc = keys %candidates;
-  $ostreamLog->print( "We have $nb_desc description candidates.\n") if($opt_verbose or $opt_output);
+  $ostreamLog->print( "We have $nb_desc description candidates.\n") if ($opt_verbose or $opt_output);
 
 ##################################################
 ####### Step 2 : go through all candidates ####### report gene name for each mRNA
@@ -784,19 +784,19 @@ sub parse_blast {
   my %geneName;
   my %linkBmRNAandGene;
 
-  foreach my $l2 (keys %candidates){
-    if( $candidates{$l2}[0] eq "error" ){
-      $ostreamLog->print( "error nothing found for $candidates{$l2}[2]\n") if($opt_verbose or $opt_output); next;
+  foreach my $l2 (keys %candidates) {
+    if ( $candidates{$l2}[0] eq "error" ) {
+      $ostreamLog->print( "error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output); next;
     }
 
     #Save uniprot id of the best match
-    print "save for $l2  ".$candidates{$l2}[2]."\n" if($opt_verbose);
+    print "save for $l2  ".$candidates{$l2}[2]."\n" if ($opt_verbose);
     $mRNAUniprotIDFromBlast{$l2} = $candidates{$l2}[2];
-    print "save for $l2  ".$candidates{$l2}[2]."\n" if($opt_verbose);
+    print "save for $l2  ".$candidates{$l2}[2]."\n" if ($opt_verbose);
     my $header = $candidates{$l2}[0];
-    print "header: ".$header."\n" if($opt_verbose);
+    print "header: ".$header."\n" if ($opt_verbose);
 
-    if ($header =~ m/(^[^\s]+)\s(.+?(?= \w{2}=))(.+)/){
+    if ($header =~ m/(^[^\s]+)\s(.+?(?= \w{2}=))(.+)/) {
       my $protID = $1;
       my $description = $2;
       my $theRest = $3;
@@ -808,25 +808,25 @@ sub parse_blast {
       #deal with the rest
       my %hash_rest;
       my $tuple=undef;
-      while ($theRest){
+      while ($theRest) {
         ($theRest, $tuple) = stringCatcher($theRest);
         my ($type,$value) = split /=/,$tuple;
         #print "$protID: type:$type --- value:$value\n";
         $hash_rest{lc($type)}=$value;
       }
 
-      if(exists($hash_rest{"gn"})){
+      if (exists($hash_rest{"gn"})) {
         $nameGene=$hash_rest{"gn"};
 
-        if(exists_keys ($hash_mRNAGeneLink,($l2)) ){
+        if (exists_keys ($hash_mRNAGeneLink,($l2)) ) {
           my $geneID = $hash_mRNAGeneLink->{$l2};
           #print "push $geneID $nameGene\n";
           push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
           push( @{ $linkBmRNAandGene{lc($geneID)}}, lc($l2)); # save mRNA name for each gene name
         }
-        else{ $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if($opt_verbose or $opt_output); }
+        else{ $ostreamLog->print( "No parent found for $l2 (defined in the blast file) in hash_mRNAGeneLink (created by the gff file).\n") if ($opt_verbose or $opt_output); }
       }
-      else{ $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if($opt_verbose or $opt_output); }
+      else{ $ostreamLog->print( "Header from the db fasta file doesn't match the regular expression: $header\n") if ($opt_verbose or $opt_output); }
       #}else{
       #  print "Nope\s".$candidates{$l2}[0]."\n";
     }
@@ -843,19 +843,19 @@ sub parse_blast {
   ####### Step 4 : CLEAN NAMES REDUNDANCY inter gene #######
 
    my %geneNewNameUsed;
-   foreach my $geneID (keys %geneName){
+   foreach my $geneID (keys %geneName) {
      $nbGeneNameInBlast++;
 
      my @mRNAList=@{$linkBmRNAandGene{$geneID}};
      my $String = $geneName{$geneID};
  #    print "$String\n";
-     if (! exists( $geneNewNameUsed{$String})){
+     if (! exists( $geneNewNameUsed{$String})) {
        $geneNewNameUsed{$String}++;
        $geneNameBlast{$geneID}=$String;
        # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
        my $cptmRNA=1;
        if ($#mRNAList != 0) {
-         foreach my $mRNA (@mRNAList){
+         foreach my $mRNA (@mRNAList) {
            $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
            $cptmRNA++;
          }
@@ -872,7 +872,7 @@ sub parse_blast {
        # link name to mRNA and and isoform name _1 _2 _3 if several mRNA
        my $cptmRNA=1;
        if ($#mRNAList != 0) {
-         foreach my $mRNA (@mRNAList){
+         foreach my $mRNA (@mRNAList) {
            $mRNANameBlast{$mRNA}=$String."_iso".$cptmRNA;
            $cptmRNA++;
          }
@@ -909,29 +909,29 @@ sub parse_interpro_tsv {
     my $db_name=$values[3];
     my $db_value=$values[4];
     my $db_tuple=$db_name.":".$db_value;
-    print "Specific dB: ".$db_tuple."\n" if($opt_verbose);
+    print "Specific dB: ".$db_tuple."\n" if ($opt_verbose);
 
     if (! grep( /^\Q$db_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {   #to avoid duplicate
       $TotalTerm{$db_name}++;
       push ( @{$functionData{$db_name}{$mRNAID}} , $db_tuple );
-      if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+      if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
         $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
         $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
       }
     }
 
     #check for interpro
-    if( $sizeList>11 ){
+    if ( $sizeList>11 ) {
       my $db_name="InterPro";
       my $interpro_value=$values[11];
       $interpro_value=~ s/\n//g;
       my $interpro_tuple = "InterPro:".$interpro_value;
-      print "interpro dB: ".$interpro_tuple."\n" if($opt_verbose);
+      print "interpro dB: ".$interpro_tuple."\n" if ($opt_verbose);
 
       if (! grep( /^\Q$interpro_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) {	#to avoid duplicate
         $TotalTerm{$db_name}++;
         push ( @{$functionData{$db_name}{$mRNAID}} , $interpro_tuple );
-        if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+        if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
           $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
           $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
         }
@@ -939,18 +939,18 @@ sub parse_interpro_tsv {
     }
 
     #check for GO
-    if( $sizeList>13 ){
+    if ( $sizeList>13 ) {
       my $db_name="GO";
       my $go_flat_list = $values[13];
       $go_flat_list=~ s/\n//g;
       my @go_list = split(/\|/,$go_flat_list); #cut at character |
-      foreach my $go_tuple (@go_list){
-        print "GO term: ".$go_tuple."\n" if($opt_verbose);
+      foreach my $go_tuple (@go_list) {
+        print "GO term: ".$go_tuple."\n" if ($opt_verbose);
 
         if (! grep( /^\Q$go_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { #to avoid duplicate
           $TotalTerm{$db_name}++;
           push ( @{$functionData{$db_name}{$mRNAID}} , $go_tuple );
-          if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+          if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
             $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
             $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
           }
@@ -959,20 +959,20 @@ sub parse_interpro_tsv {
     }
 
     #check for pathway
-    if( $sizeList>14 ){
+    if ( $sizeList>14 ) {
       my $pathway_flat_list = $values[14];
       $pathway_flat_list=~ s/\n//g;
       $pathway_flat_list=~ s/ //g;
       my  @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
-      foreach my $pathway_tuple (@pathway_list){
+      foreach my $pathway_tuple (@pathway_list) {
         my @tuple = split(/:/,$pathway_tuple); #cut at character :
         my $db_name = $tuple[0];
-        print "pathway info: ".$pathway_tuple."\n" if($opt_verbose);
+        print "pathway info: ".$pathway_tuple."\n" if ($opt_verbose);
 
         if (! grep( /^\Q$pathway_tuple\E$/, @{$functionData{$db_name}{$mRNAID}} ) ) { # to avoid duplicate
           $TotalTerm{$db_name}++;
           push ( @{$functionData{$db_name}{$mRNAID}} , $pathway_tuple );
-          if ( exists $hash_mRNAGeneLink->{$mRNAID}){ ## check if exists among our current gff annotation file analyzed
+          if ( exists $hash_mRNAGeneLink->{$mRNAID}) { ## check if exists among our current gff annotation file analyzed
             $mRNAAssociatedToTerm{$db_name}{$mRNAID}++;
             $GeneAssociatedToTerm{$db_name}{$hash_mRNAGeneLink->{$mRNAID}}++;
           }

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -69,23 +69,46 @@ my $nbTotalGOterm = 0;
 
 # OPTION MANAGMENT
 my @copyARGV = @ARGV;
-if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
-                  'b|blast=s' => \$opt_BlastFile,
-                  'd|db=s' => \$opt_dataBase,
-                  'be|blast_evalue=i' => \$opt_blastEvalue,
-                  'pe=i' => \$opt_pe,
-                  'i|interpro=s' => \$opt_InterproFile,
-                  'id=s' => \$opt_name,
-                  'idau=s' => \$opt_nameU,
-                  'nb=i' => \$nbIDstart,
-                  'o|output=s'  => \$opt_output,
-                  'v' => \$opt_verbose,
-                  'h|help!' => \$opt_help ) )
-{
-  pod2usage( { -message => 'Failed to parse command line',
-               -verbose => 1,
-               -exitval => 1 } );
+GetOptions(
+ 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
+ 'b|blast=s'                => \$opt_BlastFile,
+ 'd|db=s'                   => \$opt_dataBase,
+ 'be|blast_evalue=i'        => \$opt_blastEvalue,
+ 'pe=i'                     => \$opt_pe,
+ 'i|interpro=s'             => \$opt_InterproFile,
+ 'id=s'                     => \$opt_name,
+ 'idau=s'                   => \$opt_nameU,
+ 'nb=i'                     => \$nbIDstart,
+ 'o|output=s'               => \$opt_output,
+ 'v'                        => \$opt_verbose,
+ 'h|help!'                  => \$opt_help
+)
+or {
+  pod2usage(
+    {
+      -message => 'Failed to parse command line',
+      -verbose => 1,
+      -exitval => 1
+    }
+  );
 }
+#if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
+#                  'b|blast=s' => \$opt_BlastFile,
+#                  'd|db=s' => \$opt_dataBase,
+#                  'be|blast_evalue=i' => \$opt_blastEvalue,
+#                  'pe=i' => \$opt_pe,
+#                  'i|interpro=s' => \$opt_InterproFile,
+#                  'id=s' => \$opt_name,
+#                  'idau=s' => \$opt_nameU,
+#                  'nb=i' => \$nbIDstart,
+#                  'o|output=s'  => \$opt_output,
+#                  'v' => \$opt_verbose,
+#                  'h|help!' => \$opt_help ) )
+#{
+#  pod2usage( { -message => 'Failed to parse command line',
+#               -verbose => 1,
+#               -exitval => 1 } );
+#}
 
 # Print Help and exit
 if ($opt_help) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -946,8 +946,7 @@ sub parse_blast {
   }
 
   # JN: Begin traversing gene_name_HoH, and populate global hash l2_gn_present_hash
-  print Debug(\%gene_name_HoH);warn "\n gene_name_HoH. Should have long key and potentially several gene names (hit return to continue)\n" and getc();
-
+  print Dumper(\%gene_name_HoH);warn "\n gene_name_HoH. Should have long key and potentially several gene names (hit return to continue)\n" and getc();
   while ( my ($l2_key, $values) = each %gene_name_HoH ) { # Key: 'maker-bi03_p1mp_001088f-est_gff_stringtie-gene-0.2-mrna-1' , value: {'hema' => 1}
     my $size = 0;
     if (defined($values)) { # JN: If defined, we have at least one GN
@@ -964,8 +963,7 @@ sub parse_blast {
       $l2_gn_present_hash{$l2_key} = "no"; # JN: gn_present=no
     }
   }
-  print Dumper(\%l2_gn_present_hash);warn "\n l2_gn_present_hash should have yes or no, and long maker... labels (hit return to continue)\n" and getc();
-
+  print Dumper(\%l2_gn_present_hash);warn "\n l2_gn_present_hash should have keys:long maker... labels and values: yes or no, and long maker... labels (hit return to continue)\n" and getc();
   # JN: End traversing gene_name_HoH
 
   ####################################################

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -808,7 +808,7 @@ sub parse_blast {
         if (exists($fasta_id_gn_hash{$l2_name})) {    # JN: Key exists if gene name or undef
           if (defined($fasta_id_gn_hash{$l2_name})) { # JN: Only defined if gene name
             my $gn = $fasta_id_gn_hash{$l2_name};     # JN: Get the gene name
-            $gene_name_HoH{$lc_prot_name}{$gn}++;     # JN: Count the gene name
+            $gene_name_HoH{$l2_name}{$gn}++;          # JN: Count the gene name
           }
           else {                                      # JN: If not defined, the 'GN=' is missing
             undef($gene_name_HoH{$lc_prot_name});
@@ -948,7 +948,6 @@ sub parse_blast {
   # JN: Begin traversing gene_name_HoH, and populate global hash l2_gn_present_hash
   print Debug(\%gene_name_HoH);warn "\n gene_name_HoH. Should have long key and potentially several gene names (hit return to continue)\n" and getc();
 
-  # JN: fre 11 jun 2021 10:24:20: the key in the hash l2_gn_present_hash need to be the (e.g.) ''
   while ( my ($l2_key, $values) = each %gene_name_HoH ) { # Key: 'maker-bi03_p1mp_001088f-est_gff_stringtie-gene-0.2-mrna-1' , value: {'hema' => 1}
     my $size = 0;
     if (defined($values)) { # JN: If defined, we have at least one GN

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -324,11 +324,8 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           } # first time we have given this name
         }
         else { # JN: Start DEBUG
-          if ($DEBUG) {
-              $missing_name_in_blast_counter++;
-              #print Dumper($feature_level1);warn "\n printed feature_level1. AND id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
-          } # JN: End DEBUG
-        }
+          create_or_replace_tag($feature_level1, 'Name', 'DEBUG_unnamed_gene_level1'); # JN: Debug output
+        } # End DEBUG
       }
 
       #################
@@ -337,7 +334,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}) { # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
 
         if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_key_level2, $id_level1) ) ) {
-          foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_key_level2}{$id_level1}}) {
+          foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_key_level2}{$id_level1}} ) {
 
             my $level2_ID = lc($feature_level2->_tag_value('ID'));
             # Clean NAME attribute
@@ -352,6 +349,10 @@ if ($opt_BlastFile || $opt_InterproFile ) {
                 my $mRNABlastName = $mRNANameBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'Name', $mRNABlastName);
               }
+              else { # JN: Start DEBUG
+                create_or_replace_tag($feature_level2, 'Name', 'DEBUG_unnamed_gene_level2'); # JN: Debug output
+              } # End DEBUG
+
               my $productData = printProductFunct($level2_ID);
 
               #add UniprotID attribute
@@ -374,9 +375,8 @@ if ($opt_BlastFile || $opt_InterproFile ) {
                   create_or_replace_tag($feature_level2, 'Note', "product:hypothetical protein");
                 }
                 else {
-                  create_or_replace_tag($feature_level2, 'product', "hypothetical protein");
+                  create_or_replace_tag($feature_level2, 'product', "hypothetical protein"); # JN: check Luciles case here?
                 }
-
               } #Case where the protein is not known
             }
 
@@ -403,10 +403,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       }
     }
   }
-  # JN: Begin DEBUG
-  #if ($DEBUG) {
-  #  print Dumper($missing_name_in_blast_counter);warn "\n missing_name_in_blast_counter (hit return to continue)\n" and getc();
-  #} # JN: End DEBUG
 }
 
 ###########################

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -1191,7 +1191,7 @@ will not be reported.
 
 =head1 SYNOPSIS
 
-    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][-d uniprot.fasta][-i interpro_infile.tsv][-id ABCDEF][-a][-o output]
+    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][-d uniprot.fasta][-i interpro_infile.tsv][--id ABCDEF][-a][-o output]
     agat_sp_manage_functional_annotation.pl --help
 
 =head1 OPTIONS
@@ -1248,7 +1248,7 @@ This option is used to define the number that will be used to begin the numberin
 =item B<-a> or B<--addgntag>
 
 Add information in ouptut gff about if gene-name tag ('GN=') is present in blast db fasta ('gn_present=yes')
-or not ('gn_present=no'). Blast hits without entry in blast db will receive 'gn_present=no'.
+or not ('gn_present=no'). Blast hits without an entry in the blast db will receive 'gn_present=NA'.
 
 =item B<-o> or B<--output>
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -596,7 +596,11 @@ if ($opt_BlastFile) {
   $stringPrint .= "\n$nbGeneNameInBlast gene names have been retrieved in the blast file. $nbNamedGene gene names have been successfully inferred.\n".
   "Among them there are $nbGeneDuplicated names that are shared at least per two genes for a total of $nbDuplicateNameGiven genes.\n";
   # "We have $nbDuplicateName gene names duplicated ($nbDuplicateNameGiven - $nbGeneDuplicated).";
-  $stringPrint .= "\n$missing_gn_in_fasta_counter entries in db have no GN\n"; # JN: Tentative output
+
+  # JN: Report number of entries in $opt_dataBase without GN
+  if ($opt_dataBase) {
+      $stringPrint .= "\n$missing_gn_in_fasta_counter entries in $opt_dataBase have no GN\n"; # JN: Tentative output
+  }
 
   #Lets keep track the duplicated names
   if ($opt_output) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -14,7 +14,7 @@ use Bio::Tools::GFF;
 use AGAT::Omniscient;
 
 #use Data::Dumper; # JN: for dedug printing
-my $DEBUG = 1;    # JN: for dedug printing
+my $DEBUG = 0;    # JN: for dedug printing
 
 my $header = get_agat_header();
 # PARAMETERS - OPTION

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -260,6 +260,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
   # == LEVEL 1 == #
   #################
   my $missing_name_counter = 0; # JN: DEBUG
+  my $missing_name_in_blast_counter = 0; # JN: DEBUG
 
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
     foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
@@ -303,7 +304,8 @@ if ($opt_BlastFile || $opt_InterproFile ) {
         }
         else { # JN: Start DEBUG
           if ($DEBUG) {
-            print Dumper($feature_level1);warn "\n printed feature_level1. AND id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
+              $missing_name_in_blast_counter++;
+              #print Dumper($feature_level1);warn "\n printed feature_level1. AND id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
           } # JN: End DEBUG
         }
       }
@@ -383,6 +385,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
   # JN: Begin DEBUG
   if ($DEBUG) {
     print Dumper($missing_name_counter);warn "\n missing_name_counter (hit return to continue)\n" and getc();
+    print Dumper($missing_name_in_blast_counter);warn "\n missing_name_in_blast_counter (hit return to continue)\n" and getc();
   } # JN: End DEBUG
 }
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -243,7 +243,7 @@ if (defined $opt_BlastFile) {
     }
     else {
       $missing_gn_in_fasta_counter++;
-      $fasta_id_gn_hash{$lc_display_id} = "missing_gn";
+      $fasta_id_gn_hash{$lc_display_id} = "DEBUG_missing_gn"; # JN: Need a better string
     }
   }
   print_time("Parsing Finished\n\n");
@@ -799,6 +799,11 @@ sub parse_blast {
             $ostreamLog->print( "No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
             $candidates{$l2_name} = ["error", $evalue, $prot_name."-".$l2_name];
           }
+          else { # JN: Begin DEBUG 
+            if ($DEBUG) {
+              #### JN: LOOK HERE ####
+            }
+          } # JN: End DEBUG
           if ($header =~ /PE=([1-5])\s/) {
             if ($1 <= $opt_pe) {
               $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
@@ -824,6 +829,11 @@ sub parse_blast {
           # JN: No gene name
           $ostreamLog->print("No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
         }
+        else { # JN: Begin DEBUG
+          if ($DEBUG) {
+            #### JN: LOOK HERE ####
+          }
+        } # JN: End DEBUG
         if ($header =~ /PE=([1-5])\s/) {
           if ($1 <= $opt_pe) {
             $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
@@ -880,7 +890,7 @@ sub parse_blast {
         $hash_rest{lc($type)} = $value;
       }
 
-      if (exists($hash_rest{"gn"})) { # JN: Check for Gene name?
+      if (exists($hash_rest{"gn"})) { # JN: Check for Gene name? #### JN: LOOK HERE ####
         $nameGene = $hash_rest{"gn"};
 
         if (exists_keys ($hash_mRNAGeneLink, ($l2)) ) { # JN: Gene name is only captured if key exists here 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -1120,7 +1120,7 @@ will not be reported.
 
 =head1 SYNOPSIS
 
-    agat_sp_manage_functional_annotation.pl -f infile.gff [ -b blast_infile --db uniprot.fasta -i interpro_infile.tsv --id ABCDEF --output outfile ]
+    agat_sp_manage_functional_annotation.pl -f infile.gff [-b blast_infile][--db uniprot.fasta][-i interpro_infile.tsv][--id ABCDEF][--output outfile]
     agat_sp_manage_functional_annotation.pl --help
 
 =head1 OPTIONS

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -260,9 +260,9 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
   # == LEVEL 1 == #
   #################
 
-    if ($DEBUG) { # JN: Start DEBUG
-        print Dumper(%{$hash_omniscient->{'level1'}});warn "\n Level 1 (hit return to continue)\n" and getc();
-    } # JN: End DEBUG
+  #if ($DEBUG) { # JN: Start DEBUG
+  #  print Dumper(%{$hash_omniscient->{'level1'}});warn "\n Level 1 (hit return to continue)\n" and getc();
+  #} # JN: End DEBUG
 
 
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
@@ -271,18 +271,19 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
       my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
       #print $feature_level1."\n";
-      if ($DEBUG) { # JN: Start DEBUG
-        print Dumper($feature_level1);warn "\n feature_level1 (hit return to continue)\n" and getc();
-      } # JN: End DEBUG
+      #if ($DEBUG) { # JN: Start DEBUG
+      #  print Dumper($feature_level1);warn "\n feature_level1 (hit return to continue)\n" and getc();
+      #} # JN: End DEBUG
 
       # Clean NAME attribute
+      # JN: Why do we need to remove the tag?
       if ($feature_level1->has_tag('Name')) {
         $feature_level1->remove_tag('Name');
       }
 
       #Manage Name if option setting
       if ( $opt_BlastFile ) {
-        if (exists ($geneNameBlast{$id_level1})) {
+        if (exists ($geneNameBlast{$id_level1})) { # JN: Does the Name exists in the geneNameBlast hash? If not, no name is stored!
           create_or_replace_tag($feature_level1, 'Name', $geneNameBlast{$id_level1});
           $nbNamedGene++;
 
@@ -308,7 +309,7 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
         }
         else {
           if ($DEBUG) { # JN: Start DEBUG
-            print Dumper();warn "\n id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
+            print Dumper($feature_level1);warn "\n printed feature_level1. AND id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
           } # JN: End DEBUG
         }
 
@@ -317,6 +318,10 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
       #################
       # == LEVEL 2 == #
       #################
+      if ($DEBUG) { # JN: Start DEBUG
+        print Dumper(%{$hash_omniscient->{'level2'}});warn "\n level 2 hash (hit return to continue)\n" and getc();
+      } # JN: End DEBUG
+
       foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}) { # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
 
         if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_key_level2, $id_level1) ) ) {

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -253,33 +253,27 @@ if (defined $opt_InterproFile) {
 
 ###########################
 # change FUNCTIONAL information if asked for
-if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproFile) {
+if ($opt_BlastFile || $opt_InterproFile ) {
   print_time( "load FUNCTIONAL information\n" );
 
   #################
   # == LEVEL 1 == #
   #################
-
-  #if ($DEBUG) { # JN: Start DEBUG
-  #  print Dumper(%{$hash_omniscient->{'level1'}});warn "\n Level 1 (hit return to continue)\n" and getc();
-  #} # JN: End DEBUG
-
+  my $missing_name_counter = 0; # JN: DEBUG
 
   foreach my $primary_tag_level1 (keys %{$hash_omniscient ->{'level1'}}) { # primary_tag_level1 = gene or repeat etc...
     foreach my $id_level1 (keys %{$hash_omniscient ->{'level1'}{$primary_tag_level1}}) {
 
       my $feature_level1 = $hash_omniscient->{'level1'}{$primary_tag_level1}{$id_level1};
 
-      #print $feature_level1."\n";
-      #if ($DEBUG) { # JN: Start DEBUG
-      #  print Dumper($feature_level1);warn "\n feature_level1 (hit return to continue)\n" and getc();
-      #} # JN: End DEBUG
-
       # Clean NAME attribute
       # JN: Why do we need to remove the tag?
       if ($feature_level1->has_tag('Name')) {
         $feature_level1->remove_tag('Name');
       }
+      elsif($DEBUG) { # JN: Begin DEBUG
+        $missing_name_counter++; 
+      } # JN: End DEBUG
 
       #Manage Name if option setting
       if ( $opt_BlastFile ) {
@@ -307,21 +301,16 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
             $geneNameGiven{$nameToCompare}++;
           } # first time we have given this name
         }
-        else {
-          if ($DEBUG) { # JN: Start DEBUG
+        else { # JN: Start DEBUG
+          if ($DEBUG) {
             print Dumper($feature_level1);warn "\n printed feature_level1. AND id_level1 does not exist in geneNameBlast hash (hit return to continue)\n" and getc();
           } # JN: End DEBUG
         }
-
       }
 
       #################
       # == LEVEL 2 == #
       #################
-      if ($DEBUG) { # JN: Start DEBUG
-        print Dumper(%{$hash_omniscient->{'level2'}});warn "\n level 2 hash (hit return to continue)\n" and getc();
-      } # JN: End DEBUG
-
       foreach my $primary_tag_key_level2 (keys %{$hash_omniscient->{'level2'}}) { # primary_tag_key_level2 = mrna or mirna or ncrna or trna etc...
 
         if ( exists_keys ($hash_omniscient, ('level2', $primary_tag_key_level2, $id_level1) ) ) {
@@ -392,7 +381,10 @@ if ($opt_BlastFile || $opt_InterproFile ) { #|| $opt_BlastFile || $opt_InterproF
     }
   }
 }
-
+# JN: Begin DEBUG
+if ($DEBUG) {
+  print Dumper($missing_name_counter);warn "\n missing_name_counter (hit return to continue)\n" and getc();
+} # JN: End DEBUG
 
 ###########################
 # change names if asked for

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -83,15 +83,11 @@ GetOptions(
  'v'                        => \$opt_verbose,
  'h|help!'                  => \$opt_help
 )
-or {
-  pod2usage(
-    {
-      -message => 'Failed to parse command line',
-      -verbose => 1,
-      -exitval => 1
-    }
-  );
-}
+or pod2usage( {
+  -message => 'Failed to parse command line',
+  -verbose => 1,
+  -exitval => 1
+});
 #if ( !GetOptions( 'f|ref|reffile|gff|gff3=s' => \$opt_reffile,
 #                  'b|blast=s' => \$opt_BlastFile,
 #                  'd|db=s' => \$opt_dataBase,

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -811,7 +811,7 @@ sub parse_blast {
             $gene_name_HoH{$l2_name}{$gn}++;               # JN: Count the gene name
           }
           else {                                           # JN: If not defined, the 'GN=' is missing
-            undef($gene_name_HoH{$lc_prot_name});
+            undef($gene_name_HoH{$l2_name});
           }
         }
         # JN: End Debug gene_name_HoH
@@ -850,10 +850,10 @@ sub parse_blast {
       if (exists($fasta_id_gn_hash{$lc_prot_name})) {    # JN: Key exists if gene name or undef
         if (defined($fasta_id_gn_hash{$lc_prot_name})) { # JN: Only defined if gene name
           my $gn = $fasta_id_gn_hash{$lc_prot_name};     # JN: Get the gene name
-          $gene_name_HoH{$lc_prot_name}{$gn}++;          # JN: Count the gene name
+          $gene_name_HoH{$l2_name}{$gn}++;               # JN: Count the gene name
         }
         else {                                           # JN: If not defined, the 'GN=' is missing
-          undef($gene_name_HoH{$lc_prot_name});
+          undef($gene_name_HoH{$l2_name});
         }
       }
       # JN: End Debug gene_name_HoH

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -13,6 +13,9 @@ use Bio::DB::Fasta;
 use Bio::Tools::GFF;
 use AGAT::Omniscient;
 
+use Data::Dumper; # JN: dedug
+my $DEBUG = 1; # JN: debug
+
 my $header = get_agat_header();
 # PARAMETERS - OPTION
 my $opt_reffile;

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -305,8 +305,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
 
       #Manage Name if option setting
       if ( $opt_BlastFile ) {
-        #print Dumper(\%geneNameBlast);warn "\n First check of id_level:$id_level1 in hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
-        # JN: example: 'maker-bi03_p1mp_000079f-est_gff_stringtie-gene-3.1' => 'tmem259_3'
 
         if (exists ($geneNameBlast{$id_level1})) { # JN: Does the Name exists in the geneNameBlast hash? If not, no name is stored!
           create_or_replace_tag($feature_level1, 'Name', $geneNameBlast{$id_level1});
@@ -348,8 +346,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_key_level2}{$id_level1}} ) {
 
             my $level2_ID = lc($feature_level2->_tag_value('ID'));
-            print Dumper($level2_ID);warn "\n $level2_ID (hit return to continue)\n" and getc(); # JN: tmp debug
-
+            print Dumper($level2_ID);warn "\n level2_ID (hit return to continue)\n" and getc(); # JN: tmp debug
 
             # Clean NAME attribute
             if ($feature_level2->has_tag('Name')) {
@@ -391,7 +388,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
                   create_or_replace_tag($feature_level2, 'Note', "product:hypothetical protein");
                 }
                 else {
-                  create_or_replace_tag($feature_level2, 'product', "hypothetical protein"); # JN: check Luciles case here?
+                  create_or_replace_tag($feature_level2, 'product', "hypothetical protein");
                 }
               } #Case where the protein is not known
             }
@@ -419,7 +416,6 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       }
     }
   }
-  #print Dumper(\%geneNameBlast);warn "\n hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
 }
 
 ###########################

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -250,7 +250,7 @@ if (defined $opt_BlastFile) { # JN: example file uniprot_sprot.fasta
     }
     else {
       $missing_gn_in_fasta_counter++;
-      $fasta_id_gn_hash{$lc_display_id} = "DEBUG_missing_GN_in_db"; # JN: Need a better string
+      $fasta_id_gn_hash{$lc_display_id} = 'DEBUG_missing_GN_in_db'; # JN: Need a better string
     }
   }
   print_time("Parsing Finished\n\n");
@@ -804,14 +804,16 @@ sub parse_blast {
     if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}} > 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
 
-        my $lc_prot_name = lc($prot_name); # JN: Begin debug HoH
-        my $gn_presence = '';
+        my $lc_prot_name = lc($prot_name); # JN: begin Debug HoH
+        my $gn_presence = ''; # JN: Consider using 'NA' as default value?
         if (exists($fasta_id_gn_hash{$lc_prot_name})) {
           $gn_presence = $fasta_id_gn_hash{$lc_prot_name};
           $HoH{$l2_name}{$gn_presence}++;
+          # JN: Consider adding a 'NA' for the cases where the id was not in the fasta db?
         }
         else {
-          warn "\n$lc_prot_name not found in fasta_id_gn_hash (hit return to continue)\n" and getc();
+          # JN: In my example file, not all blast hits are in the example fasta db!
+          #$ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast.\n" ) if ($opt_verbose or $opt_output);
         } # JN: End Debug HoH
 
         my $protID_correct = undef;
@@ -831,6 +833,7 @@ sub parse_blast {
               #### JN: and add info about presence of GN here?
             }
           } # JN: End DEBUG
+
           if ($header =~ /PE=([1-5])\s/) {
             if ($1 <= $opt_pe) {
               $candidates{$l2_name} = [$header, $evalue, $uniprot_id];
@@ -855,14 +858,16 @@ sub parse_blast {
     elsif ( $evalue < $candidates{$l2_name}[1] ) { # better evalue for this record
 
       my $lc_prot_name = lc($prot_name); # JN: begin Debug HoH
-      my $gn_presence = '';
+      my $gn_presence = ''; # JN: Consider using 'NA' as default value?
       if (exists($fasta_id_gn_hash{$lc_prot_name})) {
         $gn_presence = $fasta_id_gn_hash{$lc_prot_name};
         $HoH{$l2_name}{$gn_presence}++;
+        # JN: Consider adding a 'NA' for the cases where the id was not in the fasta db?
       }
       else {
-        warn "\n$lc_prot_name not found in fasta_id_gn_hash (hit return to continue)\n" and getc();
-      }  # JN: End Debug HoH
+        # JN: In my example file, not all blast hits are in the example fasta db!
+        #$ostreamLog->print( "ERROR $prot_name not found among the db! You probably didn't give to me the same fasta file than the one used for the blast.\n" ) if ($opt_verbose or $opt_output);
+      } # JN: End Debug HoH
 
       my $protID_correct = undef;
 
@@ -955,10 +960,9 @@ sub parse_blast {
     }
   }
 
-  # JN: Next step: go through HoH and see if there are any level2 entries with any "DEBUG_missing_GN_in_db",
+  # JN: Begin gn_missing
+  # JN: Go through HoH and see if there are any level2 entries with any "DEBUG_missing_GN_in_db",
   # JN: and if so, is "DEBUG_missing_GN_in_db" the only value?
-  # JN: tor  3 jun 2021 14:08:59
-  # JN: Begin gn_missing=yes|no|NA
   my %l2_gn_missing_hash = (); # JN: Key: level2, value: gn_missing=yes
   while ( my ($l2, $values) = each %HoH ) {
     my $size = scalar(%{$values});
@@ -970,13 +974,13 @@ sub parse_blast {
         $l2_gn_missing_hash{$l2} = "no";
       }
     }
-    else {
+    else { # JN: Still need to check and handle cases(?) where we have several different hits
       my (@vals) = keys (%{$values});
         print "l2 $l2 have several values: @vals\n";
     }
   }
   print Dumper(\%l2_gn_missing_hash);warn "\n l2_gn_missing_hash (hit return to continue)\n" and getc();
-  # JN: End gn_missing=yes|no|NA
+  # JN: End gn_missing
 
 
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -946,6 +946,8 @@ sub parse_blast {
   }
 
   # JN: Begin traversing gene_name_HoH, and populate global hash l2_gn_present_hash
+  print Debug(\%gene_name_HoH);warn "\n gene_name_HoH. Should have long key and potentially several gene names (hit return to continue)\n" and getc();
+
   # JN: fre 11 jun 2021 10:24:20: the key in the hash l2_gn_present_hash need to be the (e.g.) ''
   while ( my ($l2_key, $values) = each %gene_name_HoH ) { # Key: 'maker-bi03_p1mp_001088f-est_gff_stringtie-gene-0.2-mrna-1' , value: {'hema' => 1}
     my $size = 0;
@@ -965,7 +967,7 @@ sub parse_blast {
   }
   print Dumper(\%l2_gn_present_hash);warn "\n l2_gn_present_hash should have yes or no, and long maker... labels (hit return to continue)\n" and getc();
 
-  # JN: End traverse HoH
+  # JN: End traversing gene_name_HoH
 
   ####################################################
   ####### Step 3 : Manage NAME final gene name ####### several isoforms could have different gene name reported. So we have to keep that information in some way to report only one STRING to gene name attribute of the gene feature.

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -255,7 +255,7 @@ if (defined $opt_BlastFile) {
 ########################
 # Manage Interpro File #
 if (defined $opt_InterproFile) {
-  parse_interpro_tsv($streamInter,$opt_InterproFile);
+  parse_interpro_tsv($streamInter, $opt_InterproFile);
 
   # create streamOutput
   if ($opt_output) {
@@ -427,7 +427,7 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
 
         my $letter_tag = get_letter_tag($primary_tag_level1);
 
-        if (! exists_keys(\%numbering,($letter_tag))) {
+        if (! exists_keys(\%numbering, ($letter_tag))) {
           $numbering{$letter_tag} = $nbIDstart;
         }
         $newID_level1 = manageID($prefixName, $numbering{$letter_tag}, $letter_tag );
@@ -452,10 +452,10 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
               }
 
               my $letter_tag = get_letter_tag($primary_tag_level2);
-              if (! exists_keys(\%numbering,($letter_tag))) {
+              if (! exists_keys(\%numbering, ($letter_tag))) {
                 $numbering{$letter_tag} = $nbIDstart;
               }
-              $newID_level2 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
+              $newID_level2 = manageID($prefixName, $numbering{$letter_tag}, $letter_tag);
               $numbering{$letter_tag}++;
               create_or_replace_tag($feature_level2, 'ID', $newID_level2);
               create_or_replace_tag($feature_level2, 'Parent', $newID_level1);
@@ -467,7 +467,7 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
 
               foreach my $primary_tag_level3 (keys %{$hash_omniscient->{'level3'}}) { # primary_tag_key_level3 = cds or exon or start_codon or utr etc...
 
-                  if ( exists_keys ($hash_omniscient,('level3',$primary_tag_level3, lc($level2_ID)) ) ) {
+                  if ( exists_keys ($hash_omniscient, ('level3', $primary_tag_level3, lc($level2_ID)) ) ) {
 
                     foreach my $feature_level3 ( @{$hash_omniscient->{'level3'}{$primary_tag_level3}{lc($level2_ID)}}) {
 
@@ -478,10 +478,10 @@ if ($opt_nameU || $opt_name ) { #|| $opt_BlastFile || $opt_InterproFile) {
                       }
 
                       my $letter_tag = get_letter_tag($primary_tag_level3);
-                      if (! exists_keys(\%numbering,($letter_tag))) {
+                      if (! exists_keys(\%numbering, ($letter_tag))) {
                         $numbering{$letter_tag} = $nbIDstart;
                       }
-                      my $newID_level3 = manageID($prefixName, $numbering{$letter_tag},$letter_tag);
+                      my $newID_level3 = manageID($prefixName, $numbering{$letter_tag}, $letter_tag);
                       if ( $primary_tag_level3 =~ /cds/ or $primary_tag_level3 =~ /utr/ ) {
                         if ($opt_nameU) {
                           $numbering{$letter_tag}++;
@@ -558,7 +558,7 @@ if ($opt_InterproFile) {
     my $mRNA_type_raw = $functionDataAdded{$type};
     my $mRNA_type = keys %{$mRNAAssociatedToTerm{$type}};
     my $gene_type = keys %{$GeneAssociatedToTerm{$type}};
-    $stringPrint .= "|".sizedPrint(" $type",25)."|".sizedPrint($total_type,25)."|".sizedPrint($mRNA_type_raw,25)."|".sizedPrint($mRNA_type,25)."|".sizedPrint($gene_type,25)."|\n|".$lineB."|\n";
+    $stringPrint .= "|".sizedPrint(" $type", 25)."|".sizedPrint($total_type, 25)."|".sizedPrint($mRNA_type_raw, 25)."|".sizedPrint($mRNA_type, 25)."|".sizedPrint($gene_type, 25)."|\n|".$lineB."|\n";
   }
 
   #RESUME TOTAL OF FUNCTION ATTACHED
@@ -629,7 +629,7 @@ sub get_letter_tag {
   my ($tag) = @_;
 
   $tag = lc($tag);
-  if (! exists_keys (\%tag_hash,( $tag ))) {
+  if (! exists_keys (\%tag_hash, ( $tag ))) {
 
     my $substringLength = 1;
     my $letter = uc(substr($tag, 0, $substringLength));
@@ -684,7 +684,7 @@ sub manageGeneNameBlast {
 
 # creates gene ID correctly formated (PREFIX,TYPE,NUMBER) like HOMSAPG00000000001 for a Homo sapiens gene.
 sub manageID {
-  my ($prefix,$nbName,$type) = @_;
+  my ($prefix, $nbName, $type) = @_;
   my $result = "";
   my $numberNum = 11;
   my $GoodNum = "";
@@ -773,7 +773,7 @@ sub parse_blast {
     print "Evalue: ".$evalue."\n" if ($opt_verbose);
 
     #if does not exist fill it if over the minimum evalue
-    if (! exists_keys(\%candidates,($l2_name)) or @{$candidates{$l2_name}}> 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
+    if (! exists_keys(\%candidates, ($l2_name)) or @{$candidates{$l2_name}}> 3 ) { # the second one means we saved an error message as candidates we still have to try to find a proper one
       if ( $evalue <= $opt_blastEvalue ) {
         my $protID_correct = undef;
 
@@ -859,7 +859,7 @@ sub parse_blast {
       my $tuple = undef;
       while ($theRest) {
         ($theRest, $tuple) = stringCatcher($theRest);
-        my ($type,$value) = split /=/,$tuple;
+        my ($type, $value) = split /=/, $tuple;
         #print "$protID: type:$type --- value:$value\n";
         $hash_rest{lc($type)} = $value;
       }
@@ -867,7 +867,7 @@ sub parse_blast {
       if (exists($hash_rest{"gn"})) {
         $nameGene = $hash_rest{"gn"};
 
-        if (exists_keys ($hash_mRNAGeneLink,($l2)) ) {
+        if (exists_keys ($hash_mRNAGeneLink, ($l2)) ) {
           my $geneID = $hash_mRNAGeneLink->{$l2};
           #print "push $geneID $nameGene\n";
           push ( @{ $geneName{lc($geneID)} }, lc($nameGene) );
@@ -954,7 +954,7 @@ sub stringCatcher {
 
 # method to parse Interpro file
 sub parse_interpro_tsv {
-  my($file_in,$fileName) = @_;
+  my($file_in, $fileName) = @_;
   print("Reading features from $fileName...\n");
 
   while( my $line = <$file_in>) {
@@ -1001,7 +1001,7 @@ sub parse_interpro_tsv {
       my $db_name = "GO";
       my $go_flat_list = $values[13];
       $go_flat_list =~ s/\n//g;
-      my @go_list = split(/\|/,$go_flat_list); #cut at character |
+      my @go_list = split(/\|/, $go_flat_list); #cut at character |
       foreach my $go_tuple (@go_list) {
         print "GO term: ".$go_tuple."\n" if ($opt_verbose);
 
@@ -1021,9 +1021,9 @@ sub parse_interpro_tsv {
       my $pathway_flat_list = $values[14];
       $pathway_flat_list =~ s/\n//g;
       $pathway_flat_list =~ s/ //g;
-      my @pathway_list = split(/\|/,$pathway_flat_list); #cut at character |
+      my @pathway_list = split(/\|/, $pathway_flat_list); #cut at character |
       foreach my $pathway_tuple (@pathway_list) {
-        my @tuple = split(/:/,$pathway_tuple); #cut at character :
+        my @tuple = split(/:/, $pathway_tuple); #cut at character :
         my $db_name = $tuple[0];
         print "pathway info: ".$pathway_tuple."\n" if ($opt_verbose);
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -351,6 +351,9 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           foreach my $feature_level2 ( @{$hash_omniscient->{'level2'}{$primary_tag_key_level2}{$id_level1}} ) {
 
             my $level2_ID = lc($feature_level2->_tag_value('ID'));
+            print Dumper($level2_ID);warn "\n $level2_ID (hit return to continue)\n" and getc(); # JN: tmp debug
+
+
             # Clean NAME attribute
             if ($feature_level2->has_tag('Name')) {
               $feature_level2->remove_tag('Name');

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -37,7 +37,7 @@ my @tag_list;
 # END PARAMETERS - OPTION
 
 # FOR FUNCTIONS BLAST#
-my %nameBlast;
+my %nameBlast; # JN: Where is this hash initiated?
 my %geneNameBlast; # JN: Where is this hash initiated?
 my %mRNANameBlast;
 my %mRNAUniprotIDFromBlast;
@@ -417,7 +417,7 @@ if ($opt_BlastFile || $opt_InterproFile ) {
       }
     }
   }
-  print Dumper(\%geneNameBlast);warn "\n hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
+  #print Dumper(\%geneNameBlast);warn "\n hash geneNameBlast (hit return to continue)\n" and getc(); # JN: Debug
 }
 
 ###########################
@@ -783,6 +783,7 @@ sub addFunctions {
 }
 
 # method to parse blast file
+# JN: E.g., maker_evidence_appendedByAbinitio_blast.out
 sub parse_blast {
   my($file_in, $opt_blastEvalue, $hash_mRNAGeneLink) = @_;
 
@@ -813,10 +814,12 @@ sub parse_blast {
             # JN: No gene name
             $ostreamLog->print( "No gene name (GN=) in this header $header\n") if ($opt_verbose or $opt_output);
             $candidates{$l2_name} = ["error", $evalue, $prot_name."-".$l2_name];
+            # JN: Here we have a blast hit, but no GN. Instead of "error", use the string `gn_missing=yes`? Check the "check for 'error'" below on line 885
+            #$candidates{$l2_name} = ["error", $evalue, $prot_name."-".$l2_name];
           }
           else { # JN: Begin DEBUG
             if ($DEBUG) {
-              #### JN: 
+              #### JN: and add info about presence of GN here?
             }
           } # JN: End DEBUG
           if ($header =~ /PE=([1-5])\s/) {
@@ -836,6 +839,7 @@ sub parse_blast {
       else {# JN: Begin DEBUG
         if ($DEBUG) {
           # JN: E-value not below opt_blastEvalue
+          # JN: How can we add info about 'gn_missing=NA'?
         }
       } # JN: End DEBUG
     }
@@ -879,6 +883,10 @@ sub parse_blast {
   my %linkBmRNAandGene;
 
   foreach my $l2 (keys %candidates) {
+    print Dumper($l2);warn "\n l2 (hit return to continue)\n" and getc(); # JN: debug ons  2 jun 2021 18:22:56
+    print Dumper($candidates{$l2}[0]);warn "\n candidates l2 0 header (hit return to continue)\n" and getc(); # JN:  debug ons  2 jun 2021 18:22:56
+    print Dumper($candidates{$l2}[1]);warn "\n candidates l2 1 evalue (hit return to continue)\n" and getc(); # JN:  debug ons  2 jun 2021 18:22:56
+    print Dumper($candidates{$l2}[2]);warn "\n candidates l2 2 uniprot_id (hit return to continue)\n" and getc(); # JN:  debug ons  2 jun 2021 18:22:56
     if ( $candidates{$l2}[0] eq "error" ) {
       $ostreamLog->print("error nothing found for $candidates{$l2}[2]\n") if ($opt_verbose or $opt_output);
       next;

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -14,7 +14,7 @@ use Bio::Tools::GFF;
 use AGAT::Omniscient;
 
 use Data::Dumper; # JN: dedug
-my $DEBUG = 1; # JN: debug
+my $DEBUG = 0; # JN: debug
 
 my $header = get_agat_header();
 # PARAMETERS - OPTION
@@ -324,8 +324,10 @@ if ($opt_BlastFile || $opt_InterproFile ) {
           } # first time we have given this name
         }
         else { # JN: Start DEBUG
-          create_or_replace_tag($feature_level1, 'Name', 'DEBUG_unnamed_gene_level1'); # JN: Debug output
-        } # End DEBUG
+          if ($DEBUG) {
+            create_or_replace_tag($feature_level1, 'Name', 'DEBUG_noname_level1'); # JN: Debug output
+          } # End DEBUG
+        }
       }
 
       #################
@@ -349,9 +351,11 @@ if ($opt_BlastFile || $opt_InterproFile ) {
                 my $mRNABlastName = $mRNANameBlast{$level2_ID};
                 create_or_replace_tag($feature_level2, 'Name', $mRNABlastName);
               }
-              else { # JN: Start DEBUG
-                create_or_replace_tag($feature_level2, 'Name', 'DEBUG_unnamed_gene_level2'); # JN: Debug output
-              } # End DEBUG
+              else {
+                if ($DEBUG) {# JN: Start DEBUG
+                  create_or_replace_tag($feature_level2, 'Name', 'DEBUG_noname_level2'); # JN: Debug output
+                } # End DEBUG
+              }
 
               my $productData = printProductFunct($level2_ID);
 

--- a/bin/agat_sp_manage_functional_annotation.pl
+++ b/bin/agat_sp_manage_functional_annotation.pl
@@ -13,7 +13,7 @@ use Bio::DB::Fasta;
 use Bio::Tools::GFF;
 use AGAT::Omniscient;
 
-use Data::Dumper; # JN: for dedug printing
+#use Data::Dumper; # JN: for dedug printing
 my $DEBUG = 1;    # JN: for dedug printing
 
 my $header = get_agat_header();


### PR DESCRIPTION
New pull request involving changes in the file
`agat_sp_manage_functional_annotation.pl` on the branch `functional_gn`.

New version of the script will

1. Add an option `-a` which adds a tag, `gn_present=`, in the ouptut GFF
   indicating if a `GN=` tag is present in the blast data-base fasta header.
   Possible values are `yes`, `no`, or `NA`. The non-applicable are for those
   cases where the blast hit is not present in the blast db (happens if the user
   supplies input where the blast db not necessarily overlaps with the blast out).

2. Write a summary (in the `results.txt`) about how many blast data-base fasta
   headers that are lacking the `GN=` tag, and how many mRNA:s that are lacking
   a gene name (being a subset of the first summary number).  Note that the
   placement and content of this text is tentative and up for change (to what
   ever is most useful for downstream analyses).

Apart from the added features, extensive changes where made in terms of
formatting.  This will make the total number of changes appear extensive. From
a practical perspective, however, the default behaviour is still the same as
the script version in branch `functional_gn`.  That is, backwards compatibility
is ensured.