### PR TITLE
Fix example for agat_sq_split.md

### DIFF
--- a/docs/tools/agat_sq_split.md
+++ b/docs/tools/agat_sq_split.md
@@ -9,7 +9,7 @@ GFF3 input file must be sequential.
 ## SYNOPSIS
 
 ```
-agat_sq_split.pl -i <input file> -o <output file>
+agat_sq_split.pl --input <input file> -o <output file>
 agat_sq_split.pl --help
 ```
 


### PR DESCRIPTION
Example returns an error because of incorrect use of argument `-i` instead of `--input`.