### PR TITLE
feature_levels: add missing pseudogenic SOFA L2/L3 terms

### DIFF
--- a/share/feature_levels.yaml
+++ b/share/feature_levels.yaml
@@ -193,6 +193,7 @@ level3:
 spread:
    cds: 1
    five_prime_utr: 1
+   pseudogenic_cds: 1
    start_codon: 1
    stop_codon: 1
    three_prime_utr: 1

--- a/share/feature_levels.yaml
+++ b/share/feature_levels.yaml
@@ -68,6 +68,7 @@ level1:
   protein_coding_gene: 1
   protein_match: 1
   pseudogene: 1
+  pseudogenic_region: 1
   region: topfeature
   regulatory_region: standalone
   response_element: standalone
@@ -167,6 +168,7 @@ level3:
   non_canonical_three_prime_splice_site: 1
   protein: 1
   pseudogenic_exon: 1
+  pseudogenic_cds: pseudogenic_exon
   selenocysteine: 1
   sig_peptide: exon
   splice3 : intron


### PR DESCRIPTION
This patch adds a few SOFA ontology terms for pseudogenic regions, namely pseudogenic_region for partial pseudogenes, and pseudogenic_cds to annotate formerly-coding regions of pseudogenes