### PR TITLE
fix 424 - bug in agat_sp_complement_annotations.pl / check_feature_overlap_from_l3_to_l1

### DIFF
--- a/t/scripts_output.t
+++ b/t/scripts_output.t
@@ -260,6 +260,11 @@ system(" $script --ref t/gff_syntax/in/25_test.gff  --add t/gff_syntax/in/9_test
 ok( system("diff $result $outtmp") == 0, "output $script");
 unlink $outtmp;
 
+$result = "$output_folder/agat_sp_complement_annotations_2.gff";
+system(" $script --ref $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff  --add $input_folder/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff -o $outtmp 2>&1 1>/dev/null");
+#run test
+ok( system("diff $result $outtmp") == 0, "output $script");
+unlink $outtmp;
 
 # --------check agat_sp_ensembl_output_style.pl-------------
 

--- a/t/scripts_output/in/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff
+++ b/t/scripts_output/in/agat_sp_complement_annotations/agat_sp_complement_annotations_add.gff
@@ -1,0 +1,6 @@
+Chr1	Liftoff	gene	41075	54676	.	+	.	ID=gene-gene1
+Chr1	Liftoff	mRNA	41075	54676	.	+	.	ID=rna-transcript1;Parent=gene-gene1
+Chr1	Liftoff	exon	41075	54676	.	+	.	ID=exon-transcript1-1;Parent=rna-transcript1
+Chr1	Liftoff	CDS	41311	54435	.	+	0	ID=cds-codingsequence-1.1;Parent=rna-transcript1
+Chr1	Liftoff	five_prime_UTR	41075	41310	.	+	.	ID=nbis-five_prime_utr-19342;Parent=rna-transcript1
+Chr1	Liftoff	three_prime_UTR	54436	54676	.	+	.	ID=nbis-three_prime_utr-18368;Parent=rna-transcript1

--- a/t/scripts_output/in/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff
+++ b/t/scripts_output/in/agat_sp_complement_annotations/agat_sp_complement_annotations_ref.gff
@@ -1,0 +1,6 @@
+Chr1	Helixer	gene	41064	54753	.	+	.	ID=Chr1_000001
+Chr1	Helixer	mRNA	41064	54753	.	+	.	ID=Chr1_000001.1;Parent=Chr1_000001
+Chr1	Helixer	exon	41064	54753	.	+	.	ID=Chr1_000001.1.exon.1;Parent=Chr1_000001.1
+Chr1	Helixer	five_prime_UTR	41064	41310	.	+	.	ID=Chr1_000001.1.five_prime_UTR.1;Parent=Chr1_000001.1
+Chr1	Helixer	CDS	41311	54435	.	+	0	ID=Chr1_000001.1.CDS.1;Parent=Chr1_000001.1
+Chr1	Helixer	three_prime_UTR	54436	54753	.	+	.	ID=Chr1_000001.1.three_prime_UTR.1;Parent=Chr1_000001.1

--- a/t/scripts_output/out/agat_sp_complement_annotations_2.gff
+++ b/t/scripts_output/out/agat_sp_complement_annotations_2.gff
@@ -1,0 +1,7 @@
+##gff-version 3
+Chr1	Helixer	gene	41064	54753	.	+	.	ID=Chr1_000001
+Chr1	Helixer	mRNA	41064	54753	.	+	.	ID=Chr1_000001.1;Parent=Chr1_000001
+Chr1	Helixer	exon	41064	54753	.	+	.	ID=Chr1_000001.1.exon.1;Parent=Chr1_000001.1
+Chr1	Helixer	CDS	41311	54435	.	+	0	ID=Chr1_000001.1.CDS.1;Parent=Chr1_000001.1
+Chr1	Helixer	five_prime_UTR	41064	41310	.	+	.	ID=Chr1_000001.1.five_prime_UTR.1;Parent=Chr1_000001.1
+Chr1	Helixer	three_prime_UTR	54436	54753	.	+	.	ID=Chr1_000001.1.three_prime_UTR.1;Parent=Chr1_000001.1


### PR DESCRIPTION
This bug touch the check_feature_overlap_from_l3_to_l1 function used by e.g. agat_sp_complement_annotations.pl agat_sp_fix_features_locations_duplicated.pl 