### PR TITLE
Fix typo in manual installation section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ You will have to install all prerequisites and AGAT manually.
     * using your package management tool (e.g apt for Debian, Ubuntu, and related Linux distributions)
 
     ```
-    apt install libbio-perl-perl libclone-perl libgraph-perl liblwp-useragent-determined-perl libstatistics-r-perl libcarp-clan-perl libsort-naturally-perl libfile-share-perl libfile-sharedir libfile-sharedir-install-perl libyaml-perl liblwp-protocol-https-perl libterm-progressbar-perl
+    apt install libbio-perl-perl libclone-perl libgraph-perl liblwp-useragent-determined-perl libstatistics-r-perl libcarp-clan-perl libsort-naturally-perl libfile-share-perl libfile-sharedir-perl libfile-sharedir-install-perl libyaml-perl liblwp-protocol-https-perl libterm-progressbar-perl
     ```
 
   * Optional


### PR DESCRIPTION
The `apt` command was returning `E: Unable to locate package libfile-sharedir`, blocking proper installation. I found a typo in the manual installation section: it should be `libfile-sharedir-perl` instead of `libfile-sharedir`.

This fixed installation of the necessary libraries in my machine.