### PR TITLE
Fix missing CLI aliases in Getopt::Long across multiple scripts

### DIFF
--- a/bin/agat_sp_extract_sequences.pl
+++ b/bin/agat_sp_extract_sequences.pl
@@ -58,7 +58,7 @@ if ( ! $script_parser->getoptionsfromarray(
   'eo!'                          => \$opt_extremity_only,
   'f|fa|fasta=s'                 => \$opt_fastafile,
   'full!'                        => \$opt_full,
-  'g|gff|ref=s'                      => \$opt_gfffile,
+  'g|gff=s'                      => \$opt_gfffile,
   'h|help!'                      => \$opt_help,
   'keep_attributes!'             => \$opt_keep_attributes,
   'keep_parent_attributes!'      => \$opt_keep_parent_attributes,
@@ -948,7 +948,7 @@ Use of that option on cds will give the pre-mRNA without the untraslated regions
 (To extract an mRNA as it is defined biologicaly you need to use the
 `-t exon` option with the --merge option)
 
-=item B<-g>, B<--gff> or B<-ref> <file>
+=item B<-g> or B<--gff> <file>
 
 Input GTF/GFF file.
 

--- a/bin/agat_sp_extract_sequences.pl
+++ b/bin/agat_sp_extract_sequences.pl
@@ -58,7 +58,7 @@ if ( ! $script_parser->getoptionsfromarray(
   'eo!'                          => \$opt_extremity_only,
   'f|fa|fasta=s'                 => \$opt_fastafile,
   'full!'                        => \$opt_full,
-  'g|gff=s'                      => \$opt_gfffile,
+  'g|gff|ref=s'                      => \$opt_gfffile,
   'h|help!'                      => \$opt_help,
   'keep_attributes!'             => \$opt_keep_attributes,
   'keep_parent_attributes!'      => \$opt_keep_parent_attributes,

--- a/bin/agat_sp_fix_cds_phases.pl
+++ b/bin/agat_sp_fix_cds_phases.pl
@@ -26,7 +26,7 @@ if ( ! $script_parser->getoptionsfromarray(
     $script_argv,
     'g|gff=s'          => \$opt_gff,
     'o|out|output=s'   => \$opt_output,
-    'fasta|fa=s'       => \$opt_fasta,
+    'f|fasta|fa=s'       => \$opt_fasta,
     'h|help!'          => \$opt_help )  )
 {
         pod2usage( { -message => 'Failed to parse command line',

--- a/bin/agat_sq_mask.pl
+++ b/bin/agat_sq_mask.pl
@@ -27,7 +27,7 @@ my ($shared_argv, $script_argv) = split_argv_shared_vs_script(\@ARGV);
 my $script_parser = Getopt::Long::Parser->new;
 $script_parser->configure('bundling','no_auto_abbrev');
 if ( !$script_parser->getoptionsfromarray( $script_argv,
-          'g|gff=s'         => \$opt_gfffile,
+          'g|gff|ref=s'         => \$opt_gfffile,
           'f|fa|fasta=s'    => \$opt_fastafile,
           'hm:s'            => \$opt_HardMask,
           'sm'              => \$opt_SoftMask,

--- a/bin/agat_sq_mask.pl
+++ b/bin/agat_sq_mask.pl
@@ -27,7 +27,7 @@ my ($shared_argv, $script_argv) = split_argv_shared_vs_script(\@ARGV);
 my $script_parser = Getopt::Long::Parser->new;
 $script_parser->configure('bundling','no_auto_abbrev');
 if ( !$script_parser->getoptionsfromarray( $script_argv,
-          'g|gff|ref=s'         => \$opt_gfffile,
+          'g|gff=s'         => \$opt_gfffile,
           'f|fa|fasta=s'    => \$opt_fastafile,
           'hm:s'            => \$opt_HardMask,
           'sm'              => \$opt_SoftMask,
@@ -154,7 +154,7 @@ The result is written to the specified output file, or to STDOUT.
 
 =over 8
 
-=item B<-g>, B<--gff> or B<-ref> <file>
+=item B<-g> or B<--gff> <file>
 
 Input GTF/GFF file.
 

--- a/bin/agat_sq_reverse_complement.pl
+++ b/bin/agat_sq_reverse_complement.pl
@@ -28,7 +28,7 @@ if ( ! $script_parser->getoptionsfromarray(
     $script_argv,
     'file|input|gff=s' => \$opt_gfffile,
     'f|fasta=s'        => \$opt_fastafile,
-    'o|output=s'       => \$outfile,
+    'o|out|output=s'       => \$outfile,
     'h|help!'          => \$opt_help )  )
 {
   pod2usage( { -message => "$header\nFailed to parse command line",


### PR DESCRIPTION
This fixes several discrepancies between the help documentation and the actual `Getopt::Long` parsing logic across multiple scripts.